### PR TITLE
Fixed supported CPL schema URIs list. Since we have static helper met…

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionPlaylist.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionPlaylist.java
@@ -66,7 +66,7 @@ public final class CompositionPlaylist
     private static final String imf_cpl_schema_path = "/org/smpte_ra/schemas/st2067_3_2013/imf-cpl.xsd";
     private static final String dcmlTypes_schema_path = "/org/smpte_ra/schemas/st0433_2008/dcmlTypes/dcmlTypes.xsd";
     private static final String xmldig_core_schema_path = "/org/w3/_2000_09/xmldsig/xmldsig-core-schema.xsd";
-    private static final List<String> supportedCPLSchemaURIs = new ArrayList<String>();
+    private static final List<String> supportedCPLSchemaURIs = new ArrayList<String>(){{ add("http://www.smpte-ra.org/schemas/2067-3/2013");}};
 
     private final CompositionPlaylistType compositionPlaylistType;
     private final UUID uuid;
@@ -132,8 +132,6 @@ public final class CompositionPlaylist
         {
             throw new IMFException(String.format("Found %d errors in CompositionPlaylist XML file", imfErrorLogger.getNumberOfErrors() - numErrors));
         }
-
-        this.supportedCPLSchemaURIs.add("http://www.smpte-ra.org/schemas/2067-3/2013");
     }
 
     public String toString()

--- a/src/test/java/com/netflix/imflibrary/st2067_2/CompositionPlaylistTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_2/CompositionPlaylistTest.java
@@ -15,6 +15,7 @@ public class CompositionPlaylistTest
     {
         File inputFile = TestHelper.findResourceByPath("test_mapped_file_set/CPL_682feecb-7516-4d93-b533-f40d4ce60539.xml");
         CompositionPlaylist compositionPlaylist = new CompositionPlaylist(inputFile, null);
+        Assert.assertTrue(CompositionPlaylist.isCompositionPlaylist(inputFile));
         Assert.assertTrue(compositionPlaylist.toString().length() > 0);
         Assert.assertEquals(compositionPlaylist.getEditRate().getNumerator(), 24);
         Assert.assertEquals(compositionPlaylist.getEditRate().getDenominator(), 1);


### PR DESCRIPTION
…hods we should not rely on initializing static data from within the context of a constructor. Extended the CompositionPlaylistTest to verify that the input file is in fact an instance of the CPL schema.