### PR TITLE
Added a getter for the previous_partition field in a partition pack.

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st0377/PartitionPack.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/PartitionPack.java
@@ -485,6 +485,15 @@ public final class  PartitionPack
     }
 
     /**
+     * Getter for this partition's previous_partition byte offset.
+     *
+     * @return the previous_partition byte offset
+     */
+    public long getPreviousPartitionByteOffset(){
+        return this.previous_partition;
+    }
+
+    /**
      * Gets essence stream segment start stream position.
      *
      * @return byte offset of the start of the essence segment, relative to the start of the essence stream


### PR DESCRIPTION
This will help with any algorithms that could be implemented for an MXF essence introspection.