### PR TITLE
Audio channel label sub descriptors are mandatory per IMF Core constr…

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
@@ -674,7 +674,12 @@ public final class HeaderPartition
      */
     public List<InterchangeObject> getAudioChannelLabelSubDescriptors()
     {
-        return this.getInterchangeObjects(AudioChannelLabelSubDescriptor.class);
+        if(this.hasWaveAudioEssenceDescriptor()) {
+            return this.getInterchangeObjects(AudioChannelLabelSubDescriptor.class);
+        }
+        else{
+            return new ArrayList<InterchangeObject>();
+        }
     }
 
     /**
@@ -824,7 +829,12 @@ public final class HeaderPartition
 
     private List<InterchangeObject> getInterchangeObjects(Class clazz){
         String simpleName = clazz.getSimpleName();
-        return Collections.unmodifiableList(this.interchangeObjectsMap.get(simpleName));
+        if(this.interchangeObjectsMap.get(simpleName) == null){
+            return Collections.unmodifiableList(new ArrayList<InterchangeObject>());
+        }
+        else {
+            return Collections.unmodifiableList(this.interchangeObjectsMap.get(simpleName));
+        }
     }
 
     /*

--- a/src/test/java/com/netflix/imflibrary/st0377/HeaderPartitionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st0377/HeaderPartitionTest.java
@@ -199,6 +199,9 @@ public class HeaderPartitionTest
 
         Assert.assertTrue(headerPartition.hasAudioChannelLabelSubDescriptors());
         Assert.assertEquals(headerPartition.getAudioChannelLabelSubDescriptors().size(), 6);
+        if(headerPartition.getAudioChannelLabelSubDescriptors().size() == 0){
+            throw new MXFException(String.format("Asset seems to be invalid since it does not contain any AudioChannelLabelSubDescriptors"));
+        }
         AudioChannelLabelSubDescriptor audioChannelLabelSubDescriptor = (AudioChannelLabelSubDescriptor)headerPartition.getAudioChannelLabelSubDescriptors().get(0);
         Assert.assertEquals(audioChannelLabelSubDescriptor.getSoundfieldGroupLinkId(), soundFieldGroupMCALinkId);
         Assert.assertEquals(audioChannelLabelSubDescriptor.getMCALabelDictionaryId(), new MXFUID(new byte[]{


### PR DESCRIPTION
…aints however MXF audio essences may not contain any, hence this change to allow for clients to implement suitable behavior whether using Photon simply as a MXF validator or IMF essence component validator.