### PR TITLE
Add Dockerfile to provide PhotonIMPAnalyzer application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8
+
+ADD . /source
+
+WORKDIR /source
+
+RUN ./gradlew build
+RUN ./gradlew getDependencies
+
+ENV IMP_PATH=/media
+CMD cd /source/build/libs && java -cp /source/build/libs/*: com.netflix.imflibrary.app.PhotonIMPAnalyzer $IMP_PATH


### PR DESCRIPTION
Create the docker to run Photon everywhere.
Docker cloud was configured to build the image and create the sample image described here:
https://hub.docker.com/r/arnaudmarcantoine/photon/
