### PR TITLE
Modified the getEssenceDuration method to perform as expected.  This …

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
@@ -637,7 +637,7 @@ public final class HeaderPartition
 
             for(InterchangeObject.InterchangeObjectBO interchangeObjectBO : structuralComponentBOs){
                 StructuralComponent.StructuralComponentBO structuralComponentBO = (StructuralComponent.StructuralComponentBO) interchangeObjectBO;
-                duration += structuralComponentBO.getDuration();
+                duration = structuralComponentBO.getDuration();
             }
 
             if(duration > maxDuration){


### PR DESCRIPTION
…method should return the longest duration of the timeline tracks.  It currently returns the summation of all the durations.