### PR TITLE
Ignore synthetic fields during object construction

### DIFF
--- a/src/main/java/com/netflix/imflibrary/writerTools/utils/IMFDocumentsObjectFieldsFactory.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/utils/IMFDocumentsObjectFieldsFactory.java
@@ -85,6 +85,10 @@ public final class IMFDocumentsObjectFieldsFactory {
             Field[] fields = object.getClass().getDeclaredFields();
             Object value = null;
             for (Field field : fields) {
+                // Skip synthetic fields. They don't need to be recreated
+                if (field.isSynthetic())
+                    continue;
+
                 field.setAccessible(true);
                 boolean isPrimitiveType = isJavaPrimitiveType(field.getType());
                 boolean isJavaWrapperType = isJavaWrapperType(field.getType());


### PR DESCRIPTION
Certain testing and code coverage frameworks inject additional fields into classes during tests. These synthetic fields are not handled correctly by the reflection logic in _IMFDocumentsObjectFieldsFactory_. I added logic to ignore these fields during object construction.

There is also some additional refactoring to remove redundant code, and simplify object construction logic. 