### PR TITLE
update regxmllib to version 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     /**
      * Following includes the RegXMLLib dependency from Maven Central.
      */
-    compile "com.sandflow:regxmllib:1.1.1"
+    compile "com.sandflow:regxmllib:1.1.3"
     /**
      * Following should be enabled and the above should be disabled
      * when necessary to verify changes to the RegXMLLib library that are

--- a/src/main/java/com/netflix/imflibrary/utils/RegXMLLibHelper.java
+++ b/src/main/java/com/netflix/imflibrary/utils/RegXMLLibHelper.java
@@ -187,7 +187,7 @@ public final class RegXMLLibHelper {
             throw new MXFException(String.format("Essence Descriptors that are larger than %d bytes are not supported", Integer.MAX_VALUE));
         }
         byte[] value = byteProvider.getBytes((int) header.getVSize());
-        return new MemoryTriplet(key, value);
+        return new MemoryTriplet(new AUID(key), value);
     }
 
 


### PR DESCRIPTION
This change is necessary to upgrade the registers to the latest published version.