### PR TITLE
remove sudo: false from travis config 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-sudo: false
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh
 cache:


### PR DESCRIPTION
Closes #243

According to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration, the migration from container-based to virtual-machine-based builds has happened already. Removing this flag should have no impact.