### PR TITLE
Add support for Descriptive Metadata

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
@@ -1440,8 +1440,8 @@ public final class HeaderPartition
      * A static method to get the Header Partition from a file
      * @param inputFile source file to get the Header Partition from
      * @param imfErrorLogger logging object
-     * @return
-     * @throws IOException
+     * @return an HeaderPartition object constructed from the file
+     * @throws IOException any I/O related error will be exposed through an IOException
      */
     public static HeaderPartition fromFile(File inputFile, IMFErrorLogger imfErrorLogger) throws IOException {
         ResourceByteRangeProvider resourceByteRangeProvider = new FileByteRangeProvider(inputFile);

--- a/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/HeaderPartition.java
@@ -23,19 +23,25 @@ import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.KLVPacket;
 import com.netflix.imflibrary.MXFPropertyPopulator;
 import com.netflix.imflibrary.MXFUID;
+import com.netflix.imflibrary.RESTfulInterfaces.IMPValidator;
+import com.netflix.imflibrary.RESTfulInterfaces.PayloadRecord;
 import com.netflix.imflibrary.exceptions.MXFException;
 import com.netflix.imflibrary.st0377.header.AudioChannelLabelSubDescriptor;
 import com.netflix.imflibrary.st0377.header.CDCIPictureEssenceDescriptor;
 import com.netflix.imflibrary.st0377.header.ContentStorage;
+import com.netflix.imflibrary.st0377.header.DMFramework;
+import com.netflix.imflibrary.st0377.header.DescriptiveMarkerSegment;
 import com.netflix.imflibrary.st0377.header.EssenceContainerData;
 import com.netflix.imflibrary.st0377.header.GenericDescriptor;
 import com.netflix.imflibrary.st0377.header.GenericPackage;
 import com.netflix.imflibrary.st0377.header.GenericPictureEssenceDescriptor;
+import com.netflix.imflibrary.st0377.header.GenericStreamTextBasedSet;
 import com.netflix.imflibrary.st0377.header.GenericTrack;
 import com.netflix.imflibrary.st0377.header.GroupOfSoundFieldGroupLabelSubDescriptor;
 import com.netflix.imflibrary.st0377.header.InterchangeObject;
 import com.netflix.imflibrary.st0377.header.JPEG2000PictureSubDescriptor;
 import com.netflix.imflibrary.st0377.header.ACESPictureSubDescriptor;
+import com.netflix.imflibrary.st0377.header.StaticTrack;
 import com.netflix.imflibrary.st0377.header.TargetFrameSubDescriptor;
 import com.netflix.imflibrary.st0377.header.MaterialPackage;
 import com.netflix.imflibrary.st0377.header.PHDRMetaDataTrackSubDescriptor;
@@ -47,6 +53,8 @@ import com.netflix.imflibrary.st0377.header.SourceClip;
 import com.netflix.imflibrary.st0377.header.SourcePackage;
 import com.netflix.imflibrary.st0377.header.StructuralComponent;
 import com.netflix.imflibrary.st0377.header.StructuralMetadata;
+import com.netflix.imflibrary.st0377.header.TextBasedDMFramework;
+import com.netflix.imflibrary.st0377.header.TextBasedObject;
 import com.netflix.imflibrary.st0377.header.TimeTextResourceSubDescriptor;
 import com.netflix.imflibrary.st0377.header.TimedTextDescriptor;
 import com.netflix.imflibrary.st0377.header.TimelineTrack;
@@ -55,13 +63,18 @@ import com.netflix.imflibrary.st2067_2.AudioContentKind;
 import com.netflix.imflibrary.st2067_2.Composition;
 import com.netflix.imflibrary.st2067_201.IABEssenceDescriptor;
 import com.netflix.imflibrary.st2067_201.IABSoundfieldLabelSubDescriptor;
+import com.netflix.imflibrary.utils.ByteArrayDataProvider;
 import com.netflix.imflibrary.utils.ByteProvider;
 import com.netflix.imflibrary.utils.ErrorLogger;
+import com.netflix.imflibrary.utils.FileByteRangeProvider;
+import com.netflix.imflibrary.utils.ResourceByteRangeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -165,7 +178,7 @@ public final class HeaderPartition
             byte[] key = Arrays.copyOf(header.getKey(), header.getKey().length);
             numBytesRead += header.getKLSize();
 
-            if (StructuralMetadata.isStructuralMetadata(Arrays.copyOf(header.getKey(), header.getKey().length)))
+            if (StructuralMetadata.isStructuralMetadata(Arrays.copyOf(header.getKey(), header.getKey().length)) || StructuralMetadata.isDescriptiveMetadata(Arrays.copyOf(header.getKey(), header.getKey().length)))
             {
                 Class clazz = StructuralMetadata.getStructuralMetadataSetClass(key);
                 if(!clazz.getSimpleName().equals(Object.class.getSimpleName())){
@@ -296,6 +309,18 @@ public final class HeaderPartition
                         TimelineTrack timelineTrack = new TimelineTrack((TimelineTrack.TimelineTrackBO) interchangeObjectBO, sequence);
                         this.cacheInterchangeObject(timelineTrack);
                         uidToMetadataSets.put(interchangeObjectBO.getInstanceUID(), timelineTrack);
+                    }
+
+                } else if (interchangeObjectBO.getClass().getEnclosingClass().equals(StaticTrack.class)) {
+                    Sequence sequence = null;
+                    for (Node dependent : node.depends) {
+                        InterchangeObject dependentInterchangeObject = uidToMetadataSets.get(dependent.uid);
+                        if (dependentInterchangeObject instanceof Sequence) {
+                            sequence = (Sequence) dependentInterchangeObject;
+                        }
+                        StaticTrack staticTrack = new StaticTrack((StaticTrack.StaticTrackBO) interchangeObjectBO, sequence);
+                        this.cacheInterchangeObject(staticTrack);
+                        uidToMetadataSets.put(interchangeObjectBO.getInstanceUID(), staticTrack);
                     }
 
                 } else if (interchangeObjectBO.getClass().getEnclosingClass().equals(SourcePackage.class)) {
@@ -449,6 +474,28 @@ public final class HeaderPartition
                     TimedTextDescriptor timedTextDescriptor = new TimedTextDescriptor((TimedTextDescriptor.TimedTextDescriptorBO) interchangeObjectBO, subDescriptorList);
                     this.cacheInterchangeObject(timedTextDescriptor);
                     uidToMetadataSets.put(interchangeObjectBO.getInstanceUID(), timedTextDescriptor);
+                } else if(interchangeObjectBO.getClass().getEnclosingClass().equals(TextBasedDMFramework.class)){
+                    TextBasedObject textBasedObject = null;
+                    for(Node dependent : node.depends) {
+                        InterchangeObject dependentInterchangeObject = uidToMetadataSets.get(dependent.uid);
+                        if(dependentInterchangeObject instanceof TextBasedObject) {
+                            textBasedObject = (TextBasedObject)dependentInterchangeObject;
+                        }
+                    }
+                    TextBasedDMFramework textBasedDMFramework = new TextBasedDMFramework((TextBasedDMFramework.TextBasedDMFrameworkBO) interchangeObjectBO, textBasedObject);
+                    this.cacheInterchangeObject(textBasedDMFramework);
+                    uidToMetadataSets.put(interchangeObjectBO.getInstanceUID(), textBasedDMFramework);
+                } else if(interchangeObjectBO.getClass().getEnclosingClass().equals(DescriptiveMarkerSegment.class)){
+                    DMFramework dmFramework = null;
+                    for(Node dependent : node.depends) {
+                        InterchangeObject dependentInterchangeObject = uidToMetadataSets.get(dependent.uid);
+                        if(dependentInterchangeObject instanceof TextBasedDMFramework) {
+                            dmFramework = (TextBasedDMFramework)dependentInterchangeObject;
+                        }
+                    }
+                    DescriptiveMarkerSegment descriptiveMarkerSegment = new DescriptiveMarkerSegment((DescriptiveMarkerSegment.DescriptiveMarkerSegmentBO) interchangeObjectBO, dmFramework);
+                    this.cacheInterchangeObject(descriptiveMarkerSegment);
+                    uidToMetadataSets.put(interchangeObjectBO.getInstanceUID(), descriptiveMarkerSegment);
                 }
             }
         }
@@ -1388,4 +1435,66 @@ public final class HeaderPartition
         }
         return sb.toString();
     }
+
+    /**
+     * A static method to get the Header Partition from a file
+     * @param inputFile source file to get the Header Partition from
+     * @param imfErrorLogger logging object
+     * @return
+     * @throws IOException
+     */
+    public static HeaderPartition fromFile(File inputFile, IMFErrorLogger imfErrorLogger) throws IOException {
+        ResourceByteRangeProvider resourceByteRangeProvider = new FileByteRangeProvider(inputFile);
+
+        long archiveFileSize = resourceByteRangeProvider.getResourceSize();
+        long rangeEnd = archiveFileSize - 1;
+        long rangeStart = archiveFileSize - 4;
+        byte[] bytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
+        PayloadRecord payloadRecord = new PayloadRecord(bytes, PayloadRecord.PayloadAssetType.EssenceFooter4Bytes, rangeStart, rangeEnd);
+        Long randomIndexPackSize = IMPValidator.getRandomIndexPackSize(payloadRecord);
+
+        rangeStart = archiveFileSize - randomIndexPackSize;
+        rangeEnd = archiveFileSize - 1;
+
+        byte[] randomIndexPackBytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
+        PayloadRecord randomIndexPackPayload = new PayloadRecord(randomIndexPackBytes, PayloadRecord.PayloadAssetType.EssencePartition, rangeStart, rangeEnd);
+        List<Long> partitionByteOffsets = IMPValidator.getEssencePartitionOffsets(randomIndexPackPayload, randomIndexPackSize);
+
+        rangeStart = partitionByteOffsets.get(0);
+        rangeEnd = partitionByteOffsets.get(1) - 1;
+        byte[] headerPartitionBytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
+        ByteProvider byteProvider = new ByteArrayDataProvider(headerPartitionBytes);
+
+        return new HeaderPartition(byteProvider, 0L, headerPartitionBytes.length, imfErrorLogger);
+    }
+
+    /**
+     * Method to get the stream id (used in GenericStreamPartition) for the descriptive metadata pointed by
+     * a GenericStreamTextBasedSet object, with a given description
+     * @param description text field to match with the description field of the GenericStreamTextBasedSet object
+     * @return the generic stream id of the metadata or -1 if not found
+     */
+    public long getGenericStreamIdFromGenericStreamTextBaseSetDescription(@Nonnull String description) {
+        long sid = -1;
+        for (SourcePackage sourcePackage: this.getPreface().getContentStorage().getSourcePackageList()) {
+            for (StaticTrack staticTrack: sourcePackage.getStaticTracks()) {
+                for (DescriptiveMarkerSegment segment: staticTrack.getSequence().getDescriptiveMarkerSegments()) {
+                    DMFramework dmFramework = segment.getDmFramework();
+                    if (dmFramework instanceof TextBasedDMFramework) {
+                        TextBasedObject textBasedObject =((TextBasedDMFramework) dmFramework).getTextBaseObject();
+                        if (textBasedObject instanceof GenericStreamTextBasedSet) {
+                            if (description.equals(textBasedObject.getDescription())) {
+                                sid = ((GenericStreamTextBasedSet) textBasedObject).getGenericStreamId();
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (sid != -1) break;
+            }
+            if (sid != -1) break;
+        }
+        return sid;
+    }
+
 }

--- a/src/main/java/com/netflix/imflibrary/st0377/header/DMFramework.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/DMFramework.java
@@ -1,0 +1,25 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.KLVPacket;
+
+import javax.annotation.concurrent.Immutable;
+
+public class DMFramework extends InterchangeObject {
+
+    private final DMFrameworkBO dmFrameworkBO;
+
+    public DMFramework(DMFrameworkBO dmFrameworkBO) {
+        this.dmFrameworkBO = dmFrameworkBO;
+    }
+    /**
+     * Object corresponding to a parsed DMFramework structural metadata set defined in RP 2057:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static class DMFrameworkBO extends InterchangeObjectBO {
+        public DMFrameworkBO(KLVPacket.Header header) {
+            super(header);
+        }
+    }
+
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/DescriptiveMarkerSegment.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/DescriptiveMarkerSegment.java
@@ -39,6 +39,10 @@ public class DescriptiveMarkerSegment extends Event {
          * Instantiates a new parsed DescriptiveMarkerSegment object by virtue of parsing the MXF file bitstream
          *
          * @param header the parsed header (K and L fields from the KLV packet)
+         * @param byteProvider the input stream corresponding to the MXF file
+         * @param localTagToUIDMap mapping from local tag to element UID as provided by the Primer Pack defined in st377-1:2011
+         * @param imfErrorLogger logger for recording any parsing errors
+         * @throws IOException - any I/O related error will be exposed through an IOException
          */
         public DescriptiveMarkerSegmentBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
             super(header);

--- a/src/main/java/com/netflix/imflibrary/st0377/header/DescriptiveMarkerSegment.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/DescriptiveMarkerSegment.java
@@ -1,0 +1,88 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.MXFUID;
+import com.netflix.imflibrary.annotations.MXFProperty;
+import com.netflix.imflibrary.st0377.CompoundDataTypes;
+import com.netflix.imflibrary.utils.ByteProvider;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.IOException;
+import java.util.Map;
+
+public class DescriptiveMarkerSegment extends Event {
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + DescriptiveMarkerSegment.class.getSimpleName() + " : ";
+    private final DescriptiveMarkerSegmentBO descriptiveMarkerSegmentBO;
+    private final DMFramework dmFramework;
+
+    public DescriptiveMarkerSegment(DescriptiveMarkerSegmentBO descriptiveMarkerSegmentBO, DMFramework dmFramework) {
+        super(descriptiveMarkerSegmentBO);
+        this.descriptiveMarkerSegmentBO = descriptiveMarkerSegmentBO;
+        this.dmFramework = dmFramework;
+    }
+
+    public DMFramework getDmFramework() {
+        return dmFramework;
+    }
+
+    /**
+     * Object corresponding to a parsed DescriptiveMarkerSegment structural metadata set defined in st377-1:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static final class DescriptiveMarkerSegmentBO extends EventBO
+    {
+        @MXFProperty(size=16, depends=true) private final StrongRef dm_framework = null;
+
+        /**
+         * Instantiates a new parsed DescriptiveMarkerSegment object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         */
+        public DescriptiveMarkerSegmentBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
+            super(header);
+            long numBytesToRead = this.header.getVSize();
+
+            StructuralMetadata.populate(this, byteProvider, numBytesToRead, localTagToUIDMap);
+
+            if (this.instance_uid == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        DescriptiveMarkerSegment.ERROR_DESCRIPTION_PREFIX + "instance_uid is null");
+            }
+            if (this.dm_framework == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        DescriptiveMarkerSegment.ERROR_DESCRIPTION_PREFIX + "dmframework is null");
+            }
+        }
+
+        /**
+         * A method that returns a string representation of a DescriptiveMarkerSegmentBO object
+         *
+         * @return string representing the object
+         */
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== DescriptiveMarkerSegment ======================\n");
+            sb.append(this.header.toString());
+            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
+                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
+                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
+                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
+                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
+            sb.append(String.format("duration = %d%n", this.duration));
+            if (this.event_start_position != null) {
+                sb.append(String.format("event_start_position = %d%n", this.event_start_position));
+            }
+            if (this.event_comment != null)
+            {
+                sb.append(String.format("event_comment = %s%n", this.event_comment));
+            }
+            sb.append(this.dm_framework.toString());
+            return sb.toString();
+        }
+    }
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/Event.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/Event.java
@@ -1,0 +1,69 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.annotations.MXFProperty;
+import javax.annotation.concurrent.Immutable;
+
+public class Event extends StructuralComponent {
+
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + Event.class.getSimpleName() + " : ";
+    private final EventBO eventBO;
+
+    /**
+     * Instantiates a new Event object
+     *
+     * @param eventBO the parsed Event object
+     */
+    public Event(EventBO eventBO)
+    {
+        this.eventBO = eventBO;
+    }
+
+    /**
+     * Object corresponding to a parsed Event structural metadata set defined in st377-1:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static class EventBO extends StructuralComponentBO
+    {
+        @MXFProperty(size=8) protected final Long event_start_position = null;
+        @MXFProperty(size=0, charset = "UTF-16") protected final String event_comment = null; //UTF-16 String
+
+        /**
+         * Instantiates a new parsed Event object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         */
+        public EventBO(KLVPacket.Header header) {
+            super(header);
+        }
+
+
+        /**
+         * A method that returns a string representation of a EventBO object
+         *
+         * @return string representing the object
+         */
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== Event ======================\n");
+            sb.append(this.header.toString());
+            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
+                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
+                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
+                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
+                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
+            sb.append(String.format("duration = %d%n", this.duration));
+            if (this.event_start_position != null) {
+                sb.append(String.format("event_start_position = %d%n", this.event_start_position));
+            }
+            if (this.event_comment != null)
+            {
+                sb.append(String.format("event_comment = %s%n", this.event_comment));
+            }
+            return sb.toString();
+
+        }
+    }
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/GenericSoundEssenceDescriptor.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/GenericSoundEssenceDescriptor.java
@@ -181,6 +181,7 @@ public abstract class GenericSoundEssenceDescriptor extends FileDescriptor{
          * Constructor for a File descriptor ByteObject.
          *
          * @param header the MXF KLV header (Key and Length field)
+         * @param imfErrorLogger logger object
          */
         public GenericSoundEssenceDescriptorBO(final KLVPacket.Header header, IMFErrorLogger imfErrorLogger) {
             super(header);

--- a/src/main/java/com/netflix/imflibrary/st0377/header/GenericStreamTextBasedSet.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/GenericStreamTextBasedSet.java
@@ -38,6 +38,10 @@ public class GenericStreamTextBasedSet extends TextBasedObject {
          * Instantiates a new parsed GenericStreamTextBasedSetBO object by virtue of parsing the MXF file bitstream
          *
          * @param header the parsed header (K and L fields from the KLV packet)
+         * @param byteProvider the input stream corresponding to the MXF file
+         * @param localTagToUIDMap mapping from local tag to element UID as provided by the Primer Pack defined in st377-1:2011
+         * @param imfErrorLogger logger for recording any parsing errors
+         * @throws IOException - any I/O related error will be exposed through an IOException
          */
         public GenericStreamTextBasedSetBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
             super(header, imfErrorLogger);

--- a/src/main/java/com/netflix/imflibrary/st0377/header/GenericStreamTextBasedSet.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/GenericStreamTextBasedSet.java
@@ -1,0 +1,83 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.MXFUID;
+import com.netflix.imflibrary.annotations.MXFProperty;
+import com.netflix.imflibrary.utils.ByteProvider;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.IOException;
+import java.util.Map;
+
+public class GenericStreamTextBasedSet extends TextBasedObject {
+
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + GenericStreamTextBasedSet.class.getSimpleName() + " : ";
+    private final GenericStreamTextBasedSetBO genericStreamTextBasedSetBO;
+
+    public GenericStreamTextBasedSet(GenericStreamTextBasedSetBO genericStreamTextBasedSetBO) {
+        super(genericStreamTextBasedSetBO);
+        this.genericStreamTextBasedSetBO = genericStreamTextBasedSetBO;
+    }
+
+    public Long getGenericStreamId() {
+        return this.genericStreamTextBasedSetBO.generic_stream_id;
+    }
+
+    /**
+     * Object corresponding to a parsed GenericStreamTextBasedSet structural metadata set defined in RP 2057:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static final class GenericStreamTextBasedSetBO extends TextBasedObjectBO {
+
+        @MXFProperty(size=4) protected final Long generic_stream_id = null;
+        private final IMFErrorLogger imfErrorLogger;
+
+        /**
+         * Instantiates a new parsed GenericStreamTextBasedSetBO object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         */
+        public GenericStreamTextBasedSetBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
+            super(header, imfErrorLogger);
+            this.imfErrorLogger = imfErrorLogger;
+
+            long numBytesToRead = this.header.getVSize();
+
+            StructuralMetadata.populate(this, byteProvider, numBytesToRead, localTagToUIDMap);
+
+            postPopulateCheck();
+
+        }
+
+        protected void postPopulateCheck() {
+            super.postPopulateCheck();
+
+            if (generic_stream_id == null) {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "generic_stream_id is null");
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== TextBasedObject ======================\n");
+            sb.append(this.header.toString());
+            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
+                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
+                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
+                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
+                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
+            sb.append(String.format("mime_type = %s%n", this.mime_type));
+            sb.append(String.format("language_code = %s%n", this.language_code));
+            if (this.description != null) {
+                sb.append(String.format("description = %s%n", this.description));
+            }
+            sb.append(String.format("generic_stream_id = %d%n", this.generic_stream_id));
+            return sb.toString();
+        }
+    }
+
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/GenericTrack.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/GenericTrack.java
@@ -18,7 +18,9 @@
 
 package com.netflix.imflibrary.st0377.header;
 
+import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.MXFUID;
 import com.netflix.imflibrary.annotations.MXFProperty;
 
 /**
@@ -26,6 +28,41 @@ import com.netflix.imflibrary.annotations.MXFProperty;
  */
 public abstract class GenericTrack extends InterchangeObject
 {
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + GenericTrack.class.getSimpleName() + " : ";
+    private final Sequence sequence;
+    private final GenericTrackBO genericTrackBO;
+
+    public GenericTrack(GenericTrackBO genericTrackBO, Sequence sequence) {
+        this.sequence = sequence;
+        this.genericTrackBO = genericTrackBO;
+    }
+
+    /**
+     * Getter for the instance UID of this TimelineTrack
+     * @return the instance UID of this TimelineTrack
+     */
+    public MXFUID getInstanceUID()
+    {
+        return new MXFUID(this.genericTrackBO.instance_uid);
+    }
+
+    /**
+     * Getter for the UID of the sequence descriptive metadata set referred by this Timeline Track
+     * @return the UID of the sequence descriptive metadata set referred by this Timeline Track
+     */
+    public MXFUID getSequenceUID()
+    {
+        return this.genericTrackBO.sequence.getInstanceUID();
+    }
+
+    /**
+     * Getter for the Sequence descriptive metadata set referred by this Timeline Track
+     * @return the Sequence descriptive metadata set referred by this Timeline Track
+     */
+    public Sequence getSequence()
+    {
+        return this.sequence;
+    }
 
     @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
     public abstract static class GenericTrackBO extends InterchangeObjectBO
@@ -43,14 +80,63 @@ public abstract class GenericTrack extends InterchangeObject
          */
         @MXFProperty(size=16, depends=true) protected final StrongRef sequence = null;
 
+        private final IMFErrorLogger imfErrorLogger;
+
         /**
          * Instantiates a new Generic track ByteObject.
          *
          * @param header the header
          */
-        GenericTrackBO(KLVPacket.Header header)
+        GenericTrackBO(KLVPacket.Header header, IMFErrorLogger imfErrorLogger)
         {
+
             super(header);
+            this.imfErrorLogger = imfErrorLogger;
         }
+
+        /**
+         * Getter for the UID of the sequence descriptive metadata set referred by this Track
+         * @return the UID of the sequence descriptive metadata set referred by this Track
+         */
+        public MXFUID getSequenceUID()
+        {
+            return this.sequence.getInstanceUID();
+        }
+
+        public void postPopulateCheck() {
+            if (this.instance_uid == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "instance_uid is null");
+            }
+
+            if (this.sequence == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "sequence is null");
+            }
+        }
+
+        /**
+         * A method that returns a string representation of a Generic Track object
+         *
+         * @return string representing the object
+         */
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== GenericTrack ======================\n");
+            sb.append(this.header.toString());
+            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
+                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
+                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
+                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
+                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
+            sb.append(String.format("track_id = 0x%08x(%d)%n", this.track_id, this.track_id));
+            sb.append(String.format("track_number = 0x%08x(%d)%n", this.track_number, this.track_number));
+            sb.append(String.format("sequence = %s%n", this.sequence.toString()));
+            return sb.toString();
+        }
+
     }
 }

--- a/src/main/java/com/netflix/imflibrary/st0377/header/Sequence.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/Sequence.java
@@ -96,6 +96,24 @@ public final class Sequence extends StructuralComponent
     }
 
     /**
+     * Getter for the subset of structural components that are of type SourceClip
+     *
+     * @return the source clips
+     */
+    public List<DescriptiveMarkerSegment> getDescriptiveMarkerSegments()
+    {
+        List<DescriptiveMarkerSegment> descriptiveMarkerSegments = new ArrayList<>();
+        for (StructuralComponent structuralComponent : this.structuralComponents)
+        {
+            if (structuralComponent instanceof DescriptiveMarkerSegment)
+            {
+                descriptiveMarkerSegments.add((DescriptiveMarkerSegment)structuralComponent);
+            }
+        }
+        return descriptiveMarkerSegments;
+    }
+
+    /**
      * Getter for the instance UID of a SourceClip structural component in the list of structural components referred by this Sequence object
      * @param index - the index in the list corresponding to the SourceClip structural component
      * @return the source clips

--- a/src/main/java/com/netflix/imflibrary/st0377/header/SourcePackage.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/SourcePackage.java
@@ -109,6 +109,24 @@ public final class SourcePackage extends GenericPackage
     }
 
     /**
+     * Getter for subset of generic tracks that are of type StaticTrack
+     *
+     * @return the timeline tracks
+     */
+    public List<StaticTrack> getStaticTracks()
+    {
+        List<StaticTrack> staticTracks = new ArrayList<>();
+        for (GenericTrack genericTrack : this.genericTracks)
+        {
+            if (genericTrack instanceof StaticTrack)
+            {
+                staticTracks.add((StaticTrack)genericTrack);
+            }
+        }
+
+        return staticTracks;
+    }
+    /**
      * A method that returns a string representation of a Source Package object
      *
      * @return string representing the object

--- a/src/main/java/com/netflix/imflibrary/st0377/header/StaticTrack.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/StaticTrack.java
@@ -1,0 +1,72 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.MXFUID;
+import com.netflix.imflibrary.utils.ByteProvider;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.IOException;
+import java.util.Map;
+
+public class StaticTrack extends GenericTrack {
+
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + StaticTrack.class.getSimpleName() + " : ";
+    private final StaticTrackBO staticTrackBO;
+
+
+    /**
+     * Instantiates a new StaticTrack object
+     *
+     * @param staticTrackBO the parsed StaticTrack object
+     * @param sequence the sequence referred by this StaticTrack object
+     */
+    public StaticTrack(StaticTrackBO staticTrackBO, Sequence sequence)
+    {
+        super(staticTrackBO, sequence);
+        this.staticTrackBO = staticTrackBO;
+    }
+
+    /**
+     * Object corresponding to a parsed StaticTrack structural metadata set defined in st377-1:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static final class StaticTrackBO extends GenericTrackBO
+    {
+
+        /**
+         * Instantiates a new parsed StaticTrack object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         * @param byteProvider the input stream corresponding to the MXF file
+         * @param localTagToUIDMap mapping from local tag to element UID as provided by the Primer Pack defined in st377-1:2011
+         * @param imfErrorLogger logger for recording any parsing errors
+         * @throws IOException - any I/O related error will be exposed through an IOException
+         */
+        public StaticTrackBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger)
+                throws IOException
+        {
+            super(header, imfErrorLogger);
+            long numBytesToRead = this.header.getVSize();
+
+            StructuralMetadata.populate(this, byteProvider, numBytesToRead, localTagToUIDMap);
+
+            postPopulateCheck();
+
+        }
+
+        /**
+         * A method that returns a string representation of a Timeline Track object
+         *
+         * @return string representing the object
+         */
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append(super.toString());
+            return sb.toString();
+        }
+    }
+
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/StructuralMetadata.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/StructuralMetadata.java
@@ -46,6 +46,10 @@ public final class StructuralMetadata
     private static final byte[] KEY_BASE = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x00, 0x01, 0x00, 0x0d, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00};
     private static final byte[] KEY_MASK = {   1,    1,    1,    1,    1,    0,    1,    0,    1,    1,    1,    1,    1,    0,    0,    1};
 
+    private static final byte[] DESCRIPTIVE_KEY_BASE = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x00, 0x01, 0x00, 0x0d, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00};
+    private static final byte[] DESCRIPTIVE_KEY_MASK = {   1,    1,    1,    1,    1,    0,    1,    0,    1,    1,    1,    1,    0,    0,    0,    1};
+
+
     private static final byte[] PHDR_METADATA_TRACK_SUBDESCRIPTOR = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x53, 0x01, 0x05, 0x0e, 0x09, 0x06, 0x07, 0x01, 0x01, 0x01, 0x03};
 
 
@@ -119,6 +123,28 @@ public final class StructuralMetadata
             byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x02, 0x07 , 0x02, 0x01, 0x03, 0x01, 0x03, 0x00, 0x00};
             MXFUID mxfUL = new MXFUID(byteArray);
             map.put(mxfUL, "origin");
+        }
+        //Event
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x02, 0x07 , 0x02, 0x01, 0x03, 0x03, 0x03, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "event_start_position");
+        }
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x02, 0x05 , 0x30, 0x04, 0x04, 0x01, 0x00, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "event_comment");
+        }
+        //DMSegment
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x04, 0x01, 0x07, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "track_ids");
+        }
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x05, 0x06, 0x01, 0x01, 0x04, 0x02, 0x0c, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "dm_framework");
         }
         //CDCIPictureEssenceDescriptor
         {
@@ -579,6 +605,39 @@ public final class StructuralMetadata
             MXFUID mxfUL = new MXFUID(byteArray);
             map.put(mxfUL, "viewing_environment");
         }
+        //Text-based DM Framework
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x06, 0x01, 0x01, 0x04, 0x05, 0x41, 0x01, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "text_based_object");
+        }
+        //Text-based Object
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x04, 0x06, 0x08, 0x06, 0x00, 0x00, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "metadata_payload_scheme_id");
+        }
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x04, 0x09, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "mime_type");
+        }
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x03, 0x01, 0x01, 0x02, 0x02, 0x14, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "language_code");
+        }
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x03, 0x02, 0x01, 0x06, 0x03, 0x02, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "description");
+        }
+        //Generic Stream Text-based Set
+        {
+            byte[] byteArray = {0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x0d, 0x01, 0x03, 0x04, 0x08, 0x00, 0x00, 0x00, 0x00};
+            MXFUID mxfUL = new MXFUID(byteArray);
+            map.put(mxfUL, "generic_stream_id");
+        }
         ItemULToItemName = Collections.unmodifiableMap(map);
     }
 
@@ -598,6 +657,26 @@ public final class StructuralMetadata
         for (int i=0; i< KLVPacket.KEY_FIELD_SIZE; i++)
         {
             if( (StructuralMetadata.KEY_MASK[i] != 0) && (StructuralMetadata.KEY_BASE[i] != key[i]) )
+            {
+                return false;
+            }
+        }
+
+        return ((key[5] == 0x53) || (key[5] == 0x13));
+
+    }
+
+    /**
+     * A method that determines of the key passed in corresponds to a descriptive metadata set.
+     *
+     * @param key the key
+     * @return the boolean
+     */
+    public static boolean isDescriptiveMetadata(byte[] key)
+    {
+        for (int i=0; i< KLVPacket.KEY_FIELD_SIZE; i++)
+        {
+            if( (StructuralMetadata.DESCRIPTIVE_KEY_MASK[i] != 0) && (StructuralMetadata.DESCRIPTIVE_KEY_BASE[i] != key[i]) )
             {
                 return false;
             }
@@ -661,7 +740,7 @@ public final class StructuralMetadata
                 case 0x39 :
                     return Object.class; //Event Track
                 case 0x3A :
-                    return Object.class; //Static Track
+                    return StaticTrack.StaticTrackBO.class;
                 case 0x0F:
                     return Sequence.SequenceBO.class;
                 case 0x11 :
@@ -669,7 +748,7 @@ public final class StructuralMetadata
                 case 0x14 :
                     return TimecodeComponent.TimecodeComponentBO.class;
                 case 0x41 :
-                    return Object.class; //DM Segment
+                    return DescriptiveMarkerSegment.DescriptiveMarkerSegmentBO.class; //DM Segment
                 case 0x45 :
                     return Object.class; //DM Source Clip
                 case 0x09 :
@@ -722,6 +801,15 @@ public final class StructuralMetadata
                     return TargetFrameSubDescriptor.TargetFrameSubDescriptorBO.class;
                 default :
                     return Object.class;
+            }
+        }
+        else if (isDescriptiveMetadata(key)) { // Metadata Sets for the Text-based Metadata
+            if (key[13] == 0x02 && key[14] == 0x01) {
+                return GenericStreamTextBasedSet.GenericStreamTextBasedSetBO.class;
+            } else if (key[13] == 0x01 && key[14] == 0x01) {
+                return TextBasedDMFramework.TextBasedDMFrameworkBO.class;
+            } else {
+                return Object.class;
             }
         }
         else

--- a/src/main/java/com/netflix/imflibrary/st0377/header/StructuralMetadata.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/StructuralMetadata.java
@@ -46,8 +46,8 @@ public final class StructuralMetadata
     private static final byte[] KEY_BASE = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x00, 0x01, 0x00, 0x0d, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00};
     private static final byte[] KEY_MASK = {   1,    1,    1,    1,    1,    0,    1,    0,    1,    1,    1,    1,    1,    0,    0,    1};
 
-    private static final byte[] DESCRIPTIVE_KEY_BASE = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x00, 0x01, 0x00, 0x0d, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00};
-    private static final byte[] DESCRIPTIVE_KEY_MASK = {   1,    1,    1,    1,    1,    0,    1,    0,    1,    1,    1,    1,    0,    0,    0,    1};
+    private static final byte[] DESCRIPTIVE_METADATA_KEY_BASE = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x00, 0x01, 0x00, 0x0d, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00};
+    private static final byte[] DESCRIPTIVE_METADATA_KEY_MASK = {   1,    1,    1,    1,    1,    0,    1,    0,    1,    1,    1,    1,    0,    0,    0,    1};
 
 
     private static final byte[] PHDR_METADATA_TRACK_SUBDESCRIPTOR = {0x06, 0x0e, 0x2b, 0x34, 0x02, 0x53, 0x01, 0x05, 0x0e, 0x09, 0x06, 0x07, 0x01, 0x01, 0x01, 0x03};
@@ -676,7 +676,7 @@ public final class StructuralMetadata
     {
         for (int i=0; i< KLVPacket.KEY_FIELD_SIZE; i++)
         {
-            if( (StructuralMetadata.DESCRIPTIVE_KEY_MASK[i] != 0) && (StructuralMetadata.DESCRIPTIVE_KEY_BASE[i] != key[i]) )
+            if( (StructuralMetadata.DESCRIPTIVE_METADATA_KEY_MASK[i] != 0) && (StructuralMetadata.DESCRIPTIVE_METADATA_KEY_BASE[i] != key[i]) )
             {
                 return false;
             }

--- a/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedDMFramework.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedDMFramework.java
@@ -1,0 +1,65 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.MXFUID;
+import com.netflix.imflibrary.annotations.MXFProperty;
+import com.netflix.imflibrary.utils.ByteProvider;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.IOException;
+import java.util.Map;
+
+public class TextBasedDMFramework extends DMFramework {
+
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + TextBasedObject.class.getSimpleName() + " : ";
+    private final TextBasedDMFrameworkBO textBasedDMFrameworkBO;
+    private final TextBasedObject textBaseObject;
+
+    public TextBasedDMFramework(TextBasedDMFrameworkBO textBasedDMFrameworkBO, TextBasedObject textBasedObject) {
+        super(textBasedDMFrameworkBO);
+        this.textBasedDMFrameworkBO = textBasedDMFrameworkBO;
+        this.textBaseObject = textBasedObject;
+    }
+
+    public TextBasedObject getTextBaseObject() {
+        return textBaseObject;
+    }
+
+    /**
+     * Object corresponding to a parsed TextBasedDMFramework structural metadata set defined in RP 2057:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static class TextBasedDMFrameworkBO extends DMFrameworkBO {
+
+        @MXFProperty(size=16, depends=true) private final StrongRef text_based_object = null;
+        private final IMFErrorLogger imfErrorLogger;
+
+        /**
+         * Instantiates a new parsed GenericStreamTextBasedSetBO object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         */
+        public TextBasedDMFrameworkBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
+            super(header);
+            this.imfErrorLogger = imfErrorLogger;
+
+            long numBytesToRead = this.header.getVSize();
+
+            StructuralMetadata.populate(this, byteProvider, numBytesToRead, localTagToUIDMap);
+
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== TextBasedDMFramework ======================\n");
+            sb.append(this.header.toString());
+            if (this.text_based_object != null) {
+                sb.append(String.format("description = %s%n", this.text_based_object));
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedDMFramework.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedDMFramework.java
@@ -40,6 +40,10 @@ public class TextBasedDMFramework extends DMFramework {
          * Instantiates a new parsed GenericStreamTextBasedSetBO object by virtue of parsing the MXF file bitstream
          *
          * @param header the parsed header (K and L fields from the KLV packet)
+         * @param byteProvider the input stream corresponding to the MXF file
+         * @param localTagToUIDMap mapping from local tag to element UID as provided by the Primer Pack defined in st377-1:2011
+         * @param imfErrorLogger logger for recording any parsing errors
+         * @throws IOException - any I/O related error will be exposed through an IOException
          */
         public TextBasedDMFrameworkBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
             super(header);

--- a/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedObject.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/TextBasedObject.java
@@ -1,0 +1,92 @@
+package com.netflix.imflibrary.st0377.header;
+
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.KLVPacket;
+import com.netflix.imflibrary.annotations.MXFProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+public class TextBasedObject extends InterchangeObject {
+    private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + TextBasedObject.class.getSimpleName() + " : ";
+    private final TextBasedObjectBO textBasedObjectBO;
+
+    public TextBasedObject(TextBasedObjectBO textBasedObjectBO) {
+        this.textBasedObjectBO = textBasedObjectBO;
+    }
+
+    public String getDescription() {
+        return this.textBasedObjectBO.description;
+    }
+
+    public String getMimeType() {
+        return this.textBasedObjectBO.mime_type;
+    }
+
+    public String getLanguageCode() {
+        return this.textBasedObjectBO.language_code;
+    }
+    /**
+     * Object corresponding to a parsed TextBasedObject structural metadata set defined in RP 2057:2011
+     */
+    @Immutable
+    @SuppressWarnings({"PMD.FinalFieldCouldBeStatic"})
+    public static class TextBasedObjectBO extends InterchangeObjectBO {
+
+        @MXFProperty(size=16) protected final byte[] metadata_payload_scheme_id = null;
+        @MXFProperty(size=0, charset = "UTF-16") protected final String mime_type = null;
+        @MXFProperty(size=0, charset = "UTF-16") protected final String language_code = null;
+        @MXFProperty(size=0, charset = "UTF-16") protected final String description = null;
+        private final IMFErrorLogger imfErrorLogger;
+
+        /**
+         * Instantiates a new parsed TextBasedObjectBO object by virtue of parsing the MXF file bitstream
+         *
+         * @param header the parsed header (K and L fields from the KLV packet)
+         * @param imfErrorLogger logger for recording any parsing errors
+         */
+        TextBasedObjectBO(KLVPacket.Header header, IMFErrorLogger imfErrorLogger)
+        {
+            super(header);
+            this.imfErrorLogger = imfErrorLogger;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("================== TextBasedObject ======================\n");
+            sb.append(this.header.toString());
+            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
+                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
+                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
+                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
+                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
+            sb.append(String.format("mime_type = %s%n", this.mime_type));
+            sb.append(String.format("language_code = %s%n", this.language_code));
+            if (this.description != null) {
+                sb.append(String.format("description = %s%n", this.description));
+            }
+            return sb.toString();
+        }
+
+        protected void postPopulateCheck() {
+            if (this.metadata_payload_scheme_id == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "metadata_payload_scheme_id is null");
+            }
+
+            if (this.mime_type == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "mime_type is null");
+            }
+
+            if (this.language_code == null)
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        ERROR_DESCRIPTION_PREFIX + "language_code is null");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/netflix/imflibrary/st0377/header/TimelineTrack.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/TimelineTrack.java
@@ -37,7 +37,6 @@ public final class TimelineTrack extends GenericTrack
 {
     private static final String ERROR_DESCRIPTION_PREFIX = "MXF Header Partition: " + TimelineTrack.class.getSimpleName() + " : ";
     private final TimelineTrackBO timelineTrackBO;
-    private final Sequence sequence;
 
     /**
      * Instantiates a new TimelineTrack object
@@ -47,35 +46,8 @@ public final class TimelineTrack extends GenericTrack
      */
     public TimelineTrack(TimelineTrackBO timelineTrackBO, Sequence sequence)
     {
+        super(timelineTrackBO, sequence);
         this.timelineTrackBO = timelineTrackBO;
-        this.sequence = sequence;
-    }
-
-    /**
-     * Getter for the instance UID of this TimelineTrack
-     * @return the instance UID of this TimelineTrack
-     */
-    public MXFUID getInstanceUID()
-    {
-        return new MXFUID(this.timelineTrackBO.instance_uid);
-    }
-
-    /**
-     * Getter for the UID of the sequence descriptive metadata set referred by this Timeline Track
-     * @return the UID of the sequence descriptive metadata set referred by this Timeline Track
-     */
-    public MXFUID getSequenceUID()
-    {
-        return this.timelineTrackBO.sequence.getInstanceUID();
-    }
-
-    /**
-     * Getter for the Sequence descriptive metadata set referred by this Timeline Track
-     * @return the Sequence descriptive metadata set referred by this Timeline Track
-     */
-    public Sequence getSequence()
-    {
-        return this.sequence;
     }
 
     /**
@@ -136,22 +108,12 @@ public final class TimelineTrack extends GenericTrack
         public TimelineTrackBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger)
                 throws IOException
         {
-            super(header);
+            super(header, imfErrorLogger);
             long numBytesToRead = this.header.getVSize();
 
             StructuralMetadata.populate(this, byteProvider, numBytesToRead, localTagToUIDMap);
 
-            if (this.instance_uid == null)
-            {
-                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
-                        TimelineTrack.ERROR_DESCRIPTION_PREFIX + "instance_uid is null");
-            }
-
-            if (this.sequence == null)
-            {
-                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_ESSENCE_METADATA_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
-                        TimelineTrack.ERROR_DESCRIPTION_PREFIX + "sequence is null");
-            }
+            postPopulateCheck();
 
             if (this.edit_rate == null)
             {
@@ -162,15 +124,6 @@ public final class TimelineTrack extends GenericTrack
         }
 
         /**
-         * Getter for the UID of the sequence descriptive metadata set referred by this Timeline Track
-         * @return the UID of the sequence descriptive metadata set referred by this Timeline Track
-         */
-        public MXFUID getSequenceUID()
-        {
-            return this.sequence.getInstanceUID();
-        }
-
-        /**
          * A method that returns a string representation of a Timeline Track object
          *
          * @return string representing the object
@@ -178,16 +131,7 @@ public final class TimelineTrack extends GenericTrack
         public String toString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.append("================== TimelineTrack ======================\n");
-            sb.append(this.header.toString());
-            sb.append(String.format("instance_uid = 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%n",
-                    this.instance_uid[0], this.instance_uid[1], this.instance_uid[2], this.instance_uid[3],
-                    this.instance_uid[4], this.instance_uid[5], this.instance_uid[6], this.instance_uid[7],
-                    this.instance_uid[8], this.instance_uid[9], this.instance_uid[10], this.instance_uid[11],
-                    this.instance_uid[12], this.instance_uid[13], this.instance_uid[14], this.instance_uid[15]));
-            sb.append(String.format("track_id = 0x%08x(%d)%n", this.track_id, this.track_id));
-            sb.append(String.format("track_number = 0x%08x(%d)%n", this.track_number, this.track_number));
-            sb.append(String.format("sequence = %s%n", this.sequence.toString()));
+            sb.append(super.toString());
             sb.append("================== EditRate ======================\n");
             sb.append(this.edit_rate.toString());
             sb.append(String.format("origin = %d%n", this.origin));

--- a/src/main/java/com/netflix/imflibrary/st2067_201/IABEssenceDescriptor.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_201/IABEssenceDescriptor.java
@@ -40,9 +40,13 @@ public class IABEssenceDescriptor extends GenericSoundEssenceDescriptor {
     public static final class IABEssenceDescriptorBO extends GenericSoundEssenceDescriptor.GenericSoundEssenceDescriptorBO {
 
         /**
-         * Constructor for a File descriptor ByteObject.
+         * Constructor for a IABEssenceDescriptor ByteObject.
          *
-         * @param header the MXF KLV header (Key and Length field)
+         * @param header the parsed header (K and L fields from the KLV packet)
+         * @param byteProvider the input stream corresponding to the MXF file
+         * @param localTagToUIDMap mapping from local tag to element UID as provided by the Primer Pack defined in st377-1:2011
+         * @param imfErrorLogger logger for recording any parsing errors
+         * @throws IOException - any I/O related error will be exposed through an IOException
          */
         public IABEssenceDescriptorBO(KLVPacket.Header header, ByteProvider byteProvider, Map<Integer, MXFUID> localTagToUIDMap, IMFErrorLogger imfErrorLogger) throws IOException {
             super(header, imfErrorLogger);

--- a/src/test/java/com/netflix/imflibrary/st0377/HeaderPartitionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st0377/HeaderPartitionTest.java
@@ -211,29 +211,8 @@ public class HeaderPartitionTest
     public void videoHeaderPartitionTest2() throws IOException
     {
         File inputFile = TestHelper.findResourceByPath("TestIMP/MERIDIAN_Netflix_Photon_161006/MERIDIAN_Netflix_Photon_161006_00.mxf");
-        ResourceByteRangeProvider resourceByteRangeProvider = new FileByteRangeProvider(inputFile);
         IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
-
-        long archiveFileSize = resourceByteRangeProvider.getResourceSize();
-        long rangeEnd = archiveFileSize - 1;
-        long rangeStart = archiveFileSize - 4;
-        byte[] bytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
-        PayloadRecord payloadRecord = new PayloadRecord(bytes, PayloadRecord.PayloadAssetType.EssenceFooter4Bytes, rangeStart, rangeEnd);
-        Long randomIndexPackSize = IMPValidator.getRandomIndexPackSize(payloadRecord);
-
-        rangeStart = archiveFileSize - randomIndexPackSize;
-        rangeEnd = archiveFileSize - 1;
-
-        byte[] randomIndexPackBytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
-        PayloadRecord randomIndexPackPayload = new PayloadRecord(randomIndexPackBytes, PayloadRecord.PayloadAssetType.EssencePartition, rangeStart, rangeEnd);
-        List<Long> partitionByteOffsets = IMPValidator.getEssencePartitionOffsets(randomIndexPackPayload, randomIndexPackSize);
-
-        rangeStart = partitionByteOffsets.get(0);
-        rangeEnd = partitionByteOffsets.get(1) - 1;
-        byte[] headerPartitionBytes = resourceByteRangeProvider.getByteRangeAsBytes(rangeStart, rangeEnd);
-        ByteProvider byteProvider = new ByteArrayDataProvider(headerPartitionBytes);
-
-        HeaderPartition headerPartition = new HeaderPartition(byteProvider, 0L, headerPartitionBytes.length, imfErrorLogger);
+        HeaderPartition headerPartition = HeaderPartition.fromFile(inputFile, imfErrorLogger);
         Assert.assertTrue(headerPartition.toString().length() > 0);
         Assert.assertTrue(headerPartition.hasRGBAPictureEssenceDescriptor());
         Assert.assertFalse(headerPartition.hasCDCIPictureEssenceDescriptor());
@@ -287,5 +266,14 @@ public class HeaderPartitionTest
         Assert.assertEquals(audioChannelLabelSubDescriptor.getMCALinkId(), new MXFUID(new byte[]{
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     }));
+    }
+
+    @Test
+    public void descriptiveMetadataHeaderPartitionTest() throws IOException
+    {
+        File inputFile = TestHelper.findResourceByPath("TestIMP/IAB/MXF/meridian_2398_IAB_5f.mxf");
+        IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
+        HeaderPartition headerPartition = HeaderPartition.fromFile(inputFile, imfErrorLogger);
+        Assert.assertEquals(headerPartition.getGenericStreamIdFromGenericStreamTextBaseSetDescription("http://www.dolby.com/schemas/2018/DbmdWrapper"), 3);
     }
 }


### PR DESCRIPTION
Adds classes for the following objects defined in ST 377-1:
* StaticTrack
* Event
* DescriptiveMarkerSegment
* DMFramework

and for the following from RP 2057:
* TextBasedDMFramework
* TextBasedObject
* GenericStreamTextBasedSet

Also adds a helper method in the HeaderPartition class to find the generic stream partition id from the URN of the descriptive metadata.