### PR TITLE
Fix IAB Track Duration

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st2067_2/Composition.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Composition.java
@@ -302,12 +302,10 @@ public final class Composition {
          */
         public long getDurationInTrackEditRateUnits(){
             long duration = 0L;
-            if(this.getSequenceTypeEnum().equals(SequenceTypeEnum.MainImageSequence)
-                    || this.getSequenceTypeEnum().equals(SequenceTypeEnum.MainAudioSequence)){
-
-                for(IMFBaseResourceType imfBaseResourceType : this.resources){
-                    IMFTrackFileResourceType imfTrackFileResourceType = IMFTrackFileResourceType.class.cast(imfBaseResourceType);
-                    duration += imfTrackFileResourceType.getSourceDuration().longValue() * imfTrackFileResourceType.getRepeatCount().longValue();
+            for(IMFBaseResourceType imfBaseResourceType : this.resources){
+                // Only handle TrackFileResource sequences currently
+                if (imfBaseResourceType instanceof IMFTrackFileResourceType) {
+                    duration += imfBaseResourceType.getSourceDuration().longValue() * imfBaseResourceType.getRepeatCount().longValue();
                 }
             }
             return duration;

--- a/src/test/java/com/netflix/imflibrary/st2067_201/IABCompositionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_201/IABCompositionTest.java
@@ -2,7 +2,9 @@ package com.netflix.imflibrary.st2067_201;
 
 import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.IMFErrorLoggerImpl;
+import com.netflix.imflibrary.st2067_2.ApplicationComposition;
 import com.netflix.imflibrary.st2067_2.ApplicationCompositionFactory;
+import com.netflix.imflibrary.st2067_2.Composition;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import testUtils.TestHelper;
@@ -155,5 +157,17 @@ public class IABCompositionTest {
         IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
         ApplicationCompositionFactory.getApplicationComposition(inputFile, imfErrorLogger);
         Assert.assertEquals(imfErrorLogger.getErrors().size(), 4);
+    }
+
+    @Test
+    public void correctDurationTest() throws IOException {
+        File inputFile = TestHelper.findResourceByPath
+                ("TestIMP/IAB/CPL/IAB_CPL_valid_iabsequence.xml");
+        IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
+        ApplicationComposition composition = ApplicationCompositionFactory.getApplicationComposition(inputFile, imfErrorLogger);
+        Composition.VirtualTrack iabTrack = composition.getVirtualTracks().stream().filter(vt -> vt.getSequenceTypeEnum() == Composition.SequenceTypeEnum.IABSequence).findFirst().orElse(null);
+        Assert.assertNotNull(iabTrack);
+        Assert.assertNotEquals(iabTrack.getDuration(), 0L);
+        Assert.assertNotEquals(iabTrack.getDurationInTrackEditRateUnits(), 0L);
     }
 }


### PR DESCRIPTION
Fixed a bug where IAB tracks were returning zero duration.
Duration logic is no longer conditional to the Sequence type. Only TrackFileResource sequences are currently supported. Other subtypes may require more specialized logic.