### PR TITLE
Fixed a bug where IAB sequences were being rejected by CompositionPlaylistBuilder_2016

### DIFF
--- a/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
@@ -534,12 +534,15 @@ public class CompositionPlaylistBuilder_2016 {
                 case MainAudioSequence:
                     any.add(objectFactory.createMainAudioSequence(sequenceTypeTuple.getSequence()));
                     break;
+                case IABSequence:
+                    any.add(objectFactory.createIABSequence(sequenceTypeTuple.getSequence()));
+                    break;
                 case MarkerSequence:
                     segment.getSequenceList().setMarkerSequence(sequenceTypeTuple.getSequence());
                     break;
                 default:
-                    throw new IMFAuthoringException(String.format("Currently we only support %s, %s, and %s sequence types in building a Composition Playlist document, the type of sequence being requested is %s",
-                            Composition.SequenceTypeEnum.MainAudioSequence, Composition.SequenceTypeEnum.MainImageSequence, Composition.SequenceTypeEnum.MarkerSequence, sequenceTypeTuple.getSequenceType()));
+                    throw new IMFAuthoringException(String.format("Currently we only support %s, %s, %s, and %s sequence types in building a Composition Playlist document, the type of sequence being requested is %s",
+                            Composition.SequenceTypeEnum.MainAudioSequence, Composition.SequenceTypeEnum.MainImageSequence, Composition.SequenceTypeEnum.IABSequence, Composition.SequenceTypeEnum.MarkerSequence, sequenceTypeTuple.getSequenceType()));
             }
         }
     }

--- a/src/test/java/com/netflix/imflibrary/writerTools/IMPBuilderFunctionalTest.java
+++ b/src/test/java/com/netflix/imflibrary/writerTools/IMPBuilderFunctionalTest.java
@@ -74,7 +74,8 @@ public class IMPBuilderFunctionalTest {
                 {"TestIMP/Netflix_Sony_Plugfest_2015/CPL_BLACKL_202_HD_REC709_178_ENG_fe8cf2f4-1bcd-4145-8f72-6775af4038c4.xml", "2016", true, 1},
                 {"TestIMP/Netflix_Sony_Plugfest_2015/CPL_BLACKL_202_HD_REC709_178_ENG_fe8cf2f4-1bcd-4145-8f72-6775af4038c4_duplicate_source_encoding_element.xml", "2016", true, 1},
                 {"TestIMP/Netflix_Sony_Plugfest_2015/CPL_BLACKL_202_HD_REC709_178_ENG_fe8cf2f4-1bcd-4145-8f72-6775af4038c4.xml", "2016", false, 0},
-                {"TestIMP/Netflix_Sony_Plugfest_2015/CPL_BLACKL_202_HD_REC709_178_ENG_fe8cf2f4-1bcd-4145-8f72-6775af4038c4_duplicate_source_encoding_element.xml", "2016", false, 0}
+                {"TestIMP/Netflix_Sony_Plugfest_2015/CPL_BLACKL_202_HD_REC709_178_ENG_fe8cf2f4-1bcd-4145-8f72-6775af4038c4_duplicate_source_encoding_element.xml", "2016", false, 0},
+                {"TestIMP/IAB/CompleteIMP/CPL_e0265fda-cb35-4e35-a4e4-4f44d82d2a52.xml", "2016", false, 0},
         };
     }
 


### PR DESCRIPTION
This was caused by an explicit check for sequence type that was not updated when IAB support was originally added.