### PR TITLE
Refactoring and code cleanup related to parsing CompositionPlaylistType.

### DIFF
--- a/src/main/java/com/netflix/imflibrary/exceptions/IMFException.java
+++ b/src/main/java/com/netflix/imflibrary/exceptions/IMFException.java
@@ -58,6 +58,12 @@ public class IMFException extends RuntimeException
         this.errorLogger = errorLogger;
     }
 
+    public IMFException(String s, Throwable t, @Nonnull IMFErrorLogger errorLogger)
+    {
+        super(s, t);
+        this.errorLogger = errorLogger;
+    }
+
     public List<ErrorLogger.ErrorObject> getErrors()
     {
         List errorList = new ArrayList<ErrorLogger.ErrorObject>();

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2013.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2013.java
@@ -2,23 +2,33 @@ package com.netflix.imflibrary.st2067_2;
 
 import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.exceptions.IMFException;
-import com.netflix.imflibrary.utils.UUIDHelper;
+import com.netflix.imflibrary.utils.ErrorLogger;
+import com.netflix.imflibrary.utils.ResourceByteRangeProvider;
 import com.netflix.imflibrary.writerTools.CompositionPlaylistBuilder_2013;
+import com.netflix.imflibrary.writerTools.utils.ValidationEventHandlerImpl;
 import org.w3c.dom.Element;
-
+import org.xml.sax.SAXException;
 
 import javax.annotation.Nonnull;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * A class that models aspects of a Composition such as a VirtualTrack, TrackResources etc. compliant with the 2013 CompositionPlaylist specification st2067-3:2013.
+ * Used for converting a specific JAXB class (org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType) into the canonical, version-independent, class IMFCompositionPlaylistType
  */
 final class CompositionModel_st2067_2_2013 {
 
@@ -28,176 +38,292 @@ final class CompositionModel_st2067_2_2013 {
     }
 
     /**
-     * A stateless method that reads and parses all the virtual tracks of a Composition
+     * Converts a CompositionPlaylist from a JAXB object, into a version-independent model
      * @param compositionPlaylistType - a CompositionPlaylist object model
      * @param imfErrorLogger - an object for logging errors
-     * @return a map containing mappings of a UUID to the corresponding VirtualTrack
+     * @return A canonical, version-independent, instance of IMFCompositionPlaylistType
      */
-    public static IMFCompositionPlaylistType getCompositionPlaylist (@Nonnull org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType compositionPlaylistType, @Nonnull IMFErrorLogger imfErrorLogger) {
-        List<IMFSegmentType> segmentList = new ArrayList<IMFSegmentType>();
-        for (org.smpte_ra.schemas.st2067_2_2013.SegmentType segment : compositionPlaylistType.getSegmentList().getSegment()) {
-            List<IMFSequenceType> sequenceList = new ArrayList<IMFSequenceType>();
-            org.smpte_ra.schemas.st2067_2_2013.SequenceType sequence;
+    @Nonnull public static IMFCompositionPlaylistType getCompositionPlaylist (@Nonnull org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType compositionPlaylistType, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        // Parse each Segment
+        List<IMFSegmentType> segmentList = compositionPlaylistType.getSegmentList().getSegment().stream()
+                .map(segment -> parseSegment(segment, compositionPlaylistType.getEditRate(), imfErrorLogger))
+                .collect(Collectors.toList());
 
-            /* Parse Marker sequence */
-            sequence = segment.getSequenceList().getMarkerSequence();
-            if (sequence != null) {
-                UUID uuid = UUIDHelper.fromUUIDAsURNStringToUUID(sequence.getTrackId());
-                /**
-                 * A LinkedList seems appropriate since we want to preserve the order of the Resources referenced
-                 * by a virtual track to recreate the presentation. Since the LinkedList implementation is not
-                 * synchronized wrapping it around a synchronized list collection, although in this case it
-                 * is perhaps not required since this method is only invoked from the context of the constructor.
-                 */
-                List<IMFBaseResourceType> baseResources = Collections.synchronizedList(new LinkedList<>());
-                for (org.smpte_ra.schemas.st2067_2_2013.BaseResourceType resource : sequence.getResourceList().getResource()) {
-                    IMFBaseResourceType baseResource = null;
-                    if (resource instanceof org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType) {
-                        org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType markerResource =
-                                (org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType) resource;
-
-                        List<IMFMarkerType> markerList = new ArrayList<IMFMarkerType>();
-                        for (org.smpte_ra.schemas.st2067_2_2013.MarkerType marker : markerResource.getMarker()) {
-                            markerList.add(new IMFMarkerType(marker.getAnnotation() == null? null : marker.getAnnotation().getValue(),
-                                    new IMFMarkerType.Label(marker.getLabel().getValue(), marker.getLabel().getScope()),
-                                    marker.getOffset()));
-                        }
-
-                        try {
-                            baseResource = new IMFMarkerResourceType(
-                                    markerResource.getId(),
-                                    markerResource.getEditRate().size() != 0 ? markerResource.getEditRate() : compositionPlaylistType.getEditRate(),
-                                    markerResource.getIntrinsicDuration(),
-                                    markerResource.getEntryPoint(),
-                                    markerResource.getSourceDuration(),
-                                    markerResource.getRepeatCount(),
-                                    markerList);
-                        } catch (IMFException e) {
-                            imfErrorLogger.addAllErrors(e.getErrors());
-                        }
-
-                    } else {
-                        imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL, "Unsupported Resource type in Marker Sequence");
-                    }
-
-                    if (baseResource != null) {
-                        baseResources.add(baseResource);
-                    }
-                }
-                sequenceList.add(new IMFSequenceType(sequence.getId(),
-                        sequence.getTrackId(),
-                        Composition.SequenceTypeEnum.MarkerSequence,
-                        Collections.synchronizedList(baseResources)));
-            }
-
-            /* Parse rest of the sequences */
-            for (Object object : segment.getSequenceList().getAny()) {
-                if (!(object instanceof JAXBElement)) {
-                    String details = "";
-                    if(object instanceof Element)
-                    {
-                        Element element = Element.class.cast(object);
-                        details = "Tag: " + element.getTagName() + " URI: " + element.getNamespaceURI();
-                    }
-                    imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger
-                            .IMFErrors.ErrorLevels.NON_FATAL, String.format("Unsupported sequence type or schema %s",
-                            details));
-                    continue;
-                }
-                JAXBElement jaxbElement = (JAXBElement) (object);
-                String name = jaxbElement.getName().getLocalPart();
-                sequence = (org.smpte_ra.schemas.st2067_2_2013.SequenceType) (jaxbElement).getValue();
-                if (sequence != null) {
-                    UUID uuid = UUIDHelper.fromUUIDAsURNStringToUUID(sequence.getTrackId());
-                    /**
-                     * A LinkedList seems appropriate since we want to preserve the order of the Resources referenced
-                     * by a virtual track to recreate the presentation. Since the LinkedList implementation is not
-                     * synchronized wrapping it around a synchronized list collection, although in this case it
-                     * is perhaps not required since this method is only invoked from the context of the constructor.
-                     */
-                    List<IMFBaseResourceType> baseResources = Collections.synchronizedList(new LinkedList<>());
-                    for (org.smpte_ra.schemas.st2067_2_2013.BaseResourceType resource : sequence.getResourceList().getResource()) {
-                        IMFBaseResourceType baseResource = null;
-                        if (resource instanceof org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType) {
-
-                            org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType trackFileResource =
-                                    (org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType) resource;
-
-                            try {
-                                baseResource = new IMFTrackFileResourceType(
-                                        trackFileResource.getId(),
-                                        trackFileResource.getTrackFileId(),
-                                        trackFileResource.getEditRate().size() != 0 ? trackFileResource.getEditRate() : compositionPlaylistType.getEditRate(),
-                                        trackFileResource.getIntrinsicDuration(),
-                                        trackFileResource.getEntryPoint(),
-                                        trackFileResource.getSourceDuration(),
-                                        trackFileResource.getRepeatCount(),
-                                        trackFileResource.getSourceEncoding(),
-                                        trackFileResource.getHash(),
-                                        CompositionPlaylistBuilder_2013.defaultHashAlgorithm
-                                );
-                            } catch (IMFException e) {
-                                imfErrorLogger.addAllErrors(e.getErrors());
-                            }
-                        } else {
-                            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.WARNING, "Unsupported Resource type");
-                        }
-
-                        if (baseResource != null) {
-                            baseResources.add(baseResource);
-                        }
-                    }
-                    sequenceList.add(new IMFSequenceType(sequence.getId(),
-                            sequence.getTrackId(),
-                            Composition.SequenceTypeEnum.getSequenceTypeEnum(name),
-                            Collections.synchronizedList(baseResources)));
-                }
-            }
-            sequenceList = Collections.unmodifiableList(sequenceList);
-            segmentList.add(new IMFSegmentType(segment.getId(), Collections.synchronizedList(sequenceList)));
-        }
-        segmentList = Collections.unmodifiableList(segmentList);
-
-        List<IMFEssenceDescriptorBaseType> essenceDescriptorList = new ArrayList<IMFEssenceDescriptorBaseType>();
-
-        if (compositionPlaylistType.getEssenceDescriptorList() != null &&
-                compositionPlaylistType.getEssenceDescriptorList().getEssenceDescriptor().size() >= 1) {
-            for (org.smpte_ra.schemas.st2067_2_2013.EssenceDescriptorBaseType essenceDescriptor : compositionPlaylistType.getEssenceDescriptorList().getEssenceDescriptor()) {
-                essenceDescriptorList.add(new IMFEssenceDescriptorBaseType(essenceDescriptor.getId(),
-                        essenceDescriptor.getAny()));
-            }
-        }
-        essenceDescriptorList = Collections.unmodifiableList(essenceDescriptorList);
-
-
-        Set<String> applicationIDs = new LinkedHashSet<>();
-        if(compositionPlaylistType.getExtensionProperties() != null) {
-            for (Object object : compositionPlaylistType.getExtensionProperties().getAny()) {
-                if (object instanceof JAXBElement) {
-                    JAXBElement jaxbElement = (JAXBElement) (object);
-                    if (jaxbElement.getName().getLocalPart().equals("ApplicationIdentification")) {
-                        if (jaxbElement.getValue() instanceof List) {
-                            List applicationIDList = (List) jaxbElement.getValue();
-                            for(Object entry: applicationIDList) {
-                                if (entry instanceof String) {
-                                    applicationIDs.add(entry.toString());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        // Parse the EssenceDescriptors, if present
+        List<IMFEssenceDescriptorBaseType> essenceDescriptorList = Collections.emptyList();
+        if (compositionPlaylistType.getEssenceDescriptorList() != null)
+        {
+            essenceDescriptorList = compositionPlaylistType.getEssenceDescriptorList().getEssenceDescriptor().stream()
+                    .map(ed -> parseEssenceDescriptor(ed, imfErrorLogger))
+                    .collect(Collectors.toList());
         }
 
-        return new IMFCompositionPlaylistType(compositionPlaylistType.getId(),
+        // Parse the ApplicationIdentification values
+        Set<String> applicationIDs = parseApplicationIds(compositionPlaylistType, imfErrorLogger);
+
+        return new IMFCompositionPlaylistType( compositionPlaylistType.getId(),
                 compositionPlaylistType.getEditRate(),
                 (compositionPlaylistType.getAnnotation() == null ? null : compositionPlaylistType.getAnnotation().getValue()),
                 (compositionPlaylistType.getIssuer() == null ? null : compositionPlaylistType.getIssuer().getValue()),
                 (compositionPlaylistType.getCreator() == null ? null : compositionPlaylistType.getCreator().getValue()),
                 (compositionPlaylistType.getContentOriginator() == null ? null : compositionPlaylistType.getContentOriginator().getValue()),
                 (compositionPlaylistType.getContentTitle() == null ? null : compositionPlaylistType.getContentTitle().getValue()),
-                Collections.synchronizedList(segmentList),
-                Collections.synchronizedList(essenceDescriptorList),
-                "org.smpte_ra.schemas.st2067_2_2013", applicationIDs);
+                segmentList,
+                essenceDescriptorList,
+                "org.smpte_ra.schemas.st2067_2_2013", applicationIDs
+        );
+    }
+
+    @Nonnull static org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType unmarshallCpl(@Nonnull ResourceByteRangeProvider resourceByteRangeProvider, @Nonnull IMFErrorLogger imfErrorLogger) throws IOException
+    {
+        try (InputStream inputStream = resourceByteRangeProvider.getByteRangeAsStream(0, resourceByteRangeProvider.getResourceSize() - 1))
+        {
+            // Validate the document against the CPL schemas, when unmarshalling
+            Schema schema = CompositionModel_st2067_2_2013.ValidationSchema.INSTANCE;
+            ValidationEventHandlerImpl validationEventHandlerImpl = new ValidationEventHandlerImpl(true);
+            Unmarshaller unmarshaller = CompositionModel_st2067_2_2013.CompositionPlaylistType2013_Context.INSTANCE.createUnmarshaller();
+            unmarshaller.setEventHandler(validationEventHandlerImpl);
+            unmarshaller.setSchema(schema);
+
+            JAXBElement<org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType> jaxbCpl
+                    = unmarshaller.unmarshal(new StreamSource(inputStream), org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType.class);
+
+            // Report any schema validation errors that occurred during unmarshalling
+            if (validationEventHandlerImpl.hasErrors())
+            {
+                validationEventHandlerImpl.getErrors().stream()
+                        .map(e -> new ErrorLogger.ErrorObject(
+                                IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR,
+                                e.getValidationEventSeverity(),
+                                "Line Number : " + e.getLineNumber().toString() + " - " + e.getErrorMessage()))
+                        .forEach(imfErrorLogger::addError);
+
+                throw new IMFException(validationEventHandlerImpl.toString(), imfErrorLogger);
+            }
+
+            return jaxbCpl.getValue();
+        }
+        catch(JAXBException e)
+        {
+            throw new IMFException("Error when unmarshalling org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType", e, imfErrorLogger);
+        }
+    }
+
+    // Parse the list of ApplicationIdentification values
+    @Nonnull private static Set<String> parseApplicationIds(@Nonnull org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType compositionPlaylistType, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        if (compositionPlaylistType.getExtensionProperties() == null)
+            return Collections.emptySet();
+
+        return compositionPlaylistType.getExtensionProperties().getAny().stream()
+                .filter(JAXBElement.class::isInstance).map(JAXBElement.class::cast)
+                .filter(extProp -> extProp.getName().getLocalPart().equals("ApplicationIdentification")).map(JAXBElement::getValue)
+                .filter(List.class::isInstance).map(appIdList -> (List<?>) appIdList)
+                .findAny().orElse(Collections.emptyList()).stream().map(Object::toString).collect(Collectors.toSet());
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.EssenceDescriptorBaseType
+    // Into a canonical, version-independent, instance of IMFEssenceDescriptorBaseType
+    @Nonnull private static IMFEssenceDescriptorBaseType parseEssenceDescriptor(@Nonnull org.smpte_ra.schemas.st2067_2_2013.EssenceDescriptorBaseType essenceDescriptor, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        return new IMFEssenceDescriptorBaseType(essenceDescriptor.getId(), essenceDescriptor.getAny());
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.SegmentType
+    // Into a canonical, version-independent, instance of IMFSegmentType
+    @Nonnull private static IMFSegmentType parseSegment(@Nonnull org.smpte_ra.schemas.st2067_2_2013.SegmentType segment, @Nonnull List<Long> cplEditRate, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        List<IMFSequenceType> sequenceList = new ArrayList<IMFSequenceType>();
+
+        // Parse the Marker Sequence
+        org.smpte_ra.schemas.st2067_2_2013.SequenceType markerSequence = segment.getSequenceList().getMarkerSequence();
+        if (markerSequence != null)
+        {
+            sequenceList.add(parseMarkerSequence(markerSequence, cplEditRate, imfErrorLogger));
+        }
+
+        /* Parse rest of the sequences */
+        for (Object object : segment.getSequenceList().getAny())
+        {
+            // Ignore unrecognized Sequence types
+            if(!(object instanceof JAXBElement)){
+                String details = "";
+                if(object instanceof Element)
+                {
+                    Element element = Element.class.cast(object);
+                    details = "Tag: " + element.getTagName() + " URI: " + element.getNamespaceURI();
+                }
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger
+                        .IMFErrors.ErrorLevels.NON_FATAL, String.format("Unsupported sequence type or schema %s",
+                        details));
+                continue;
+            }
+
+            // Get the JAXB SequenceType object
+            JAXBElement jaxbElement = (JAXBElement)(object);
+            org.smpte_ra.schemas.st2067_2_2013.SequenceType sequence = (org.smpte_ra.schemas.st2067_2_2013.SequenceType) jaxbElement.getValue();
+            // Determine the type of Sequence being parsed
+            Composition.SequenceTypeEnum sequenceType = Composition.SequenceTypeEnum.getSequenceTypeEnum(jaxbElement.getName().getLocalPart());
+            // Parse the Sequence
+            sequenceList.add(parseSequence(sequence, cplEditRate, sequenceType, imfErrorLogger));
+        }
+        return new IMFSegmentType(segment.getId(), sequenceList);
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.SequenceType
+    // Into a canonical, version-independent, instance of IMFSequenceType
+    @Nonnull private static IMFSequenceType parseMarkerSequence(@Nonnull org.smpte_ra.schemas.st2067_2_2013.SequenceType markerSequence,
+                                                                @Nonnull List<Long> cplEditRate, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        List<IMFBaseResourceType> sequenceResources = new ArrayList<>();
+        for (org.smpte_ra.schemas.st2067_2_2013.BaseResourceType resource : markerSequence.getResourceList().getResource())
+        {
+            if (resource instanceof org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType)
+            {
+                try
+                {
+                    IMFMarkerResourceType markerResource = parseMarkerResource(
+                            (org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType) resource, cplEditRate, imfErrorLogger);
+                    sequenceResources.add(markerResource);
+                }
+                catch(IMFException e)
+                {
+                    imfErrorLogger.addAllErrors(e.getErrors());
+                }
+            }
+            else
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL, "Unsupported Resource type in Marker Sequence");
+            }
+        }
+        return new IMFSequenceType(markerSequence.getId(),
+                markerSequence.getTrackId(),
+                Composition.SequenceTypeEnum.MarkerSequence,
+                sequenceResources);
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.SequenceType
+    // Into a canonical, version-independent, instance of IMFSequenceType
+    @Nonnull private static IMFSequenceType parseSequence(@Nonnull org.smpte_ra.schemas.st2067_2_2013.SequenceType sequence,
+                                                          @Nonnull List<Long> cplEditRate, Composition.SequenceTypeEnum sequenceType, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        List<IMFBaseResourceType> sequenceResources = new ArrayList<>();
+        for (org.smpte_ra.schemas.st2067_2_2013.BaseResourceType resource : sequence.getResourceList().getResource())
+        {
+            if(resource instanceof  org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType)
+            {
+                try
+                {
+                    IMFTrackFileResourceType trackFileResource = parseTrackFileResource(
+                            (org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType) resource, cplEditRate, imfErrorLogger);
+                    sequenceResources.add(trackFileResource);
+                }
+                catch(IMFException e)
+                {
+                    imfErrorLogger.addAllErrors(e.getErrors());
+                }
+            }
+            else
+            {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger.IMFErrors.ErrorLevels.WARNING, "Unsupported Resource type");
+            }
+        }
+
+        return new IMFSequenceType(sequence.getId(),
+                sequence.getTrackId(),
+                sequenceType,
+                sequenceResources);
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType
+    // Into a canonical, version-independent, instance of IMFMarkerResourceType
+    @Nonnull private static IMFMarkerResourceType parseMarkerResource(@Nonnull org.smpte_ra.schemas.st2067_2_2013.MarkerResourceType markerResource,
+                                                                      @Nonnull List<Long> cplEditRate, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        // Parse each Marker within the MarkerResource
+        List<IMFMarkerType> markerList = new ArrayList<IMFMarkerType>();
+        for (org.smpte_ra.schemas.st2067_2_2013.MarkerType marker : markerResource.getMarker()) {
+            markerList.add(new IMFMarkerType(marker.getAnnotation() == null ? null : marker
+                    .getAnnotation().getValue(),
+                    new IMFMarkerType.Label(marker.getLabel().getValue(), marker.getLabel().getScope()),
+                    marker.getOffset()));
+        }
+
+        return new IMFMarkerResourceType(
+                markerResource.getId(),
+                markerResource.getEditRate().size() != 0 ? markerResource.getEditRate() : cplEditRate,
+                markerResource.getIntrinsicDuration(),
+                markerResource.getEntryPoint(),
+                markerResource.getSourceDuration(),
+                markerResource.getRepeatCount(),
+                markerList);
+    }
+
+    // Converts an instance of the JAXB class org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType
+    // Into a canonical, version-independent, instance of IMFTrackFileResourceType
+    @Nonnull private static IMFTrackFileResourceType parseTrackFileResource(@Nonnull org.smpte_ra.schemas.st2067_2_2013.TrackFileResourceType trackFileResource,
+                                                                            @Nonnull List<Long> cplEditRate, @Nonnull IMFErrorLogger imfErrorLogger)
+    {
+        return new IMFTrackFileResourceType(
+                trackFileResource.getId(),
+                trackFileResource.getTrackFileId(),
+                trackFileResource.getEditRate().size() != 0 ? trackFileResource.getEditRate() : cplEditRate,
+                trackFileResource.getIntrinsicDuration(),
+                trackFileResource.getEntryPoint(),
+                trackFileResource.getSourceDuration(),
+                trackFileResource.getRepeatCount(),
+                trackFileResource.getSourceEncoding(),
+                trackFileResource.getHash(),
+                CompositionPlaylistBuilder_2013.defaultHashAlgorithm
+        );
+    }
+
+    // Singleton to allow a JAXBContext configured for 2013 CPLs to be reused and lazy-loaded
+    private static class CompositionPlaylistType2013_Context
+    {
+        static final JAXBContext INSTANCE = createJAXBContext();
+        private static JAXBContext createJAXBContext()
+        {
+            try
+            {
+                return JAXBContext.newInstance(
+                        org.smpte_ra.schemas.st2067_2_2013.ObjectFactory.class);  // 2013 CPL and Core constraints
+            }
+            catch(JAXBException e)
+            {
+                throw new IMFException("Failed to create JAXBContext needed by CompositionPlaylistType (2013)", e);
+            }
+        }
+    }
+
+    // Singleton to allow the CPL validation Schema object to be reused and lazy-loaded
+    private static class ValidationSchema
+    {
+        static final Schema INSTANCE = createValidationSchema();
+        private static Schema createValidationSchema()
+        {
+            // Load all XSD schemas required to validate a CompositionPlaylist document
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try (InputStream xsd_xmldsig_core = contextClassLoader.getResourceAsStream("org/w3/_2000_09/xmldsig/xmldsig-core-schema.xsd");
+                 InputStream xsd_dcmlTypes = contextClassLoader.getResourceAsStream("org/smpte_ra/schemas/st0433_2008/dcmlTypes/dcmlTypes.xsd");
+                 InputStream xsd_cpl_2013 = contextClassLoader.getResourceAsStream("org/smpte_ra/schemas/st2067_3_2013/imf-cpl.xsd");
+                 InputStream xsd_core_constraints_2013 = contextClassLoader.getResourceAsStream("org/smpte_ra/schemas/st2067_2_2013/imf-core-constraints-20130620-pal.xsd");
+            )
+            {
+                // Build a schema from all of the XSD files provided
+                SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                return schemaFactory.newSchema(new StreamSource[]{
+                        new StreamSource(xsd_xmldsig_core),
+                        new StreamSource(xsd_dcmlTypes),
+                        new StreamSource(xsd_cpl_2013),
+                        new StreamSource(xsd_core_constraints_2013),
+                });
+            }
+            catch(IOException | SAXException e)
+            {
+                throw new IMFException("Unable to create CPL validation schema", e);
+            }
+        }
     }
 }

--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFCompositionPlaylistType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFCompositionPlaylistType.java
@@ -25,7 +25,6 @@ import com.netflix.imflibrary.utils.ErrorLogger;
 import com.netflix.imflibrary.utils.ResourceByteRangeProvider;
 import com.netflix.imflibrary.utils.UUIDHelper;
 import com.netflix.imflibrary.utils.Utilities;
-import com.netflix.imflibrary.writerTools.utils.ValidationEventHandlerImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.ErrorHandler;
@@ -33,22 +32,18 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * A class that models an IMF Composition Playlist structure.
@@ -120,10 +115,10 @@ final class IMFCompositionPlaylistType {
         this.creator           = creator;
         this.contentOriginator = contentOriginator;
         this.contentTitle      = contentTitle;
-        this.segmentList       = segmentList;
-        this.essenceDescriptorList  = essenceDescriptorList;
+        this.segmentList       = Collections.unmodifiableList(segmentList);
+        this.essenceDescriptorList  = Collections.unmodifiableList(essenceDescriptorList);
         this.coreConstraintsVersion = coreConstraintsVersion;
-        this.applicationIdSet = applicationIds;
+        this.applicationIdSet = Collections.unmodifiableSet(applicationIds);
 
         if(imfErrorLogger.hasFatalErrors())
         {
@@ -131,37 +126,12 @@ final class IMFCompositionPlaylistType {
         }
     }
 
-    private static class CoreConstraintsSchemas {
-        private final String coreConstraintsSchemaPath;
-        private final String coreConstraintsContext;
-
-        private CoreConstraintsSchemas(String coreConstraintsSchemaPath, String coreConstraintsContext) {
-            this.coreConstraintsSchemaPath = coreConstraintsSchemaPath;
-            this.coreConstraintsContext = coreConstraintsContext;
-        }
-
-        private String getCoreConstraintsSchemaPath() {
-            return this.coreConstraintsSchemaPath;
-        }
-
-        private String getCoreConstraintsContext() {
-            return this.coreConstraintsContext;
-        }
-    }
-    private static final List<CoreConstraintsSchemas> supportedIMFCoreConstraintsSchemas = Collections.unmodifiableList
-            (new ArrayList<CoreConstraintsSchemas>() {{
-                add(new CoreConstraintsSchemas("org/smpte_ra/schemas/st2067_2_2013/imf-core-constraints-20130620-pal.xsd", "org.smpte_ra.schemas.st2067_2_2013"));
-                add(new CoreConstraintsSchemas("org/smpte_ra/schemas/st2067_2_2016/imf-core-constraints-20160411.xsd", "org.smpte_ra.schemas.st2067_2_2016"));
-            }});
-
-    private static final String dcmlTypes_schema_path = "org/smpte_ra/schemas/st0433_2008/dcmlTypes/dcmlTypes.xsd";
-    private static final String xmldsig_core_schema_path = "org/w3/_2000_09/xmldsig/xmldsig-core-schema.xsd";
     private static final Set<String> supportedCPLSchemaURIs = Collections.unmodifiableSet(new HashSet<String>() {{
         add("http://www.smpte-ra.org/schemas/2067-3/2013");
         add("http://www.smpte-ra.org/schemas/2067-3/2016");
     }});
 
-    @Nullable
+    @Nonnull
     private static final String getCompositionNamespaceURI(ResourceByteRangeProvider resourceByteRangeProvider, @Nonnull IMFErrorLogger imfErrorLogger) throws IOException {
 
         String result = "";
@@ -215,41 +185,6 @@ final class IMFCompositionPlaylistType {
         return result;
     }
 
-    private static final String getCPLNamespaceVersion(String namespaceURI) {
-        String[] uriComponents = namespaceURI.split("/");
-        String namespaceVersion = uriComponents[uriComponents.length - 1];
-        return namespaceVersion;
-    }
-
-    private static final String serializeIMFCoreConstaintsSchemasToString(List<CoreConstraintsSchemas> coreConstraintsSchemas) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (CoreConstraintsSchemas coreConstraintsSchema : coreConstraintsSchemas) {
-            stringBuilder.append(String.format("%n"));
-            stringBuilder.append(coreConstraintsSchema.getCoreConstraintsContext());
-        }
-        return stringBuilder.toString();
-    }
-
-    private static final String getIMFCPLSchemaPath(String namespaceVersion, @Nonnull IMFErrorLogger imfErrorLogger) {
-        String imf_cpl_schema_path;
-        switch (namespaceVersion) {
-            case "2013":
-                imf_cpl_schema_path = "org/smpte_ra/schemas/st2067_3_2013/imf-cpl.xsd";
-                break;
-            case "2016":
-                imf_cpl_schema_path = "org/smpte_ra/schemas/st2067_3_2016/imf-cpl-20160411.xsd";
-                break;
-            default:
-                String message = String.format("Please check the CPL document and namespace URI, currently we " +
-                        "only support the following schema URIs %s", Utilities.serializeObjectCollectionToString
-                        (supportedCPLSchemaURIs));
-                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger.IMFErrors
-                                .ErrorLevels.FATAL,
-                        message);
-                throw new IMFException(message, imfErrorLogger);
-        }
-        return imf_cpl_schema_path;
-    }
 
     /**
      * A method that confirms if the inputStream corresponds to a Composition document instance.
@@ -281,99 +216,33 @@ final class IMFCompositionPlaylistType {
         return false;
     }
 
-    public static IMFCompositionPlaylistType getCompositionPlayListType(ResourceByteRangeProvider resourceByteRangeProvider, IMFErrorLogger imfErrorLogger) throws IOException {
-        String imf_cpl_schema_path = "";
-        try {
-            String cplNameSpaceURI = getCompositionNamespaceURI(resourceByteRangeProvider, imfErrorLogger);
+    public static IMFCompositionPlaylistType getCompositionPlayListType(ResourceByteRangeProvider resourceByteRangeProvider, IMFErrorLogger imfErrorLogger) throws IOException
+    {
+        // Determine which version of the CPL namespace is being used
+        String cplNamespace = getCompositionNamespaceURI(resourceByteRangeProvider, imfErrorLogger);
 
-            String namespaceVersion = getCPLNamespaceVersion(cplNameSpaceURI);
-            imf_cpl_schema_path = getIMFCPLSchemaPath(namespaceVersion, imfErrorLogger);
-        }
-        catch(IMFException e)
+        if (cplNamespace.equals("http://www.smpte-ra.org/schemas/2067-3/2013"))
         {
-            imfErrorLogger.addAllErrors(e.getErrors());
-            throw new IMFException("Composition creation failed", imfErrorLogger);
+            org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType jaxbCpl
+                    = CompositionModel_st2067_2_2013.unmarshallCpl(resourceByteRangeProvider, imfErrorLogger);
+
+            return CompositionModel_st2067_2_2013.getCompositionPlaylist(jaxbCpl, imfErrorLogger);
         }
+        else if (cplNamespace.equals("http://www.smpte-ra.org/schemas/2067-3/2016"))
+        {
+            org.smpte_ra.schemas.st2067_2_2016.CompositionPlaylistType jaxbCpl
+                    = CompositionModel_st2067_2_2016.unmarshallCpl(resourceByteRangeProvider, imfErrorLogger);
 
-        CoreConstraintsSchemas coreConstraintsSchema = supportedIMFCoreConstraintsSchemas.get(0);
-        JAXBElement jaxbElement = null;
-
-        for (int i = 0; i < supportedIMFCoreConstraintsSchemas.size(); i++) {
-            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            try (InputStream inputStream = resourceByteRangeProvider.getByteRangeAsStream(0, resourceByteRangeProvider.getResourceSize() - 1);
-                 InputStream xmldsig_core_is = contextClassLoader.getResourceAsStream(xmldsig_core_schema_path);
-                 InputStream dcmlTypes_is = contextClassLoader.getResourceAsStream(dcmlTypes_schema_path);
-                 InputStream imf_cpl_is = contextClassLoader.getResourceAsStream(imf_cpl_schema_path);
-                 InputStream imf_core_constraints_is = contextClassLoader.getResourceAsStream(supportedIMFCoreConstraintsSchemas.get(i).coreConstraintsSchemaPath);) {
-                StreamSource[] streamSources = new StreamSource[4];
-                streamSources[0] = new StreamSource(xmldsig_core_is);
-                streamSources[1] = new StreamSource(dcmlTypes_is);
-                streamSources[2] = new StreamSource(imf_cpl_is);
-                streamSources[3] = new StreamSource(imf_core_constraints_is);
-
-                SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-                Schema schema = schemaFactory.newSchema(streamSources);
-
-                ValidationEventHandlerImpl validationEventHandlerImpl = new ValidationEventHandlerImpl(true);
-                JAXBContext jaxbContext = JAXBContext.newInstance(supportedIMFCoreConstraintsSchemas.get(i).coreConstraintsContext);
-                Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-                unmarshaller.setEventHandler(validationEventHandlerImpl);
-                unmarshaller.setSchema(schema);
-
-                jaxbElement = (JAXBElement) unmarshaller.unmarshal(inputStream);
-                coreConstraintsSchema = supportedIMFCoreConstraintsSchemas.get(i);
-
-                if (validationEventHandlerImpl.hasErrors()) {
-                    validationEventHandlerImpl.getErrors().stream()
-                            .map(e -> new ErrorLogger.ErrorObject(
-                                    IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR,
-                                    e.getValidationEventSeverity(),
-                                    "Line Number : " + e.getLineNumber().toString() + " - " + e.getErrorMessage())
-                            )
-                            .forEach(imfErrorLogger::addError);
-
-                    throw new IMFException(validationEventHandlerImpl.toString(), imfErrorLogger);
-                }
-                break; //No errors so we can break out without trying other Core constraints schema namespaces.
-            } catch (SAXException | JAXBException e) {
-                if (i == supportedIMFCoreConstraintsSchemas.size() - 1) {
-                    imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger
-                                    .IMFErrors.ErrorLevels.FATAL,
-                            e.getMessage());
-                    throw new IMFException(e.getMessage(), imfErrorLogger);
-                }
-            }
+            return CompositionModel_st2067_2_2016.getCompositionPlaylist(jaxbCpl, imfErrorLogger);
         }
-
-        String coreConstraintsVersion = coreConstraintsSchema.getCoreConstraintsContext();
-        IMFCompositionPlaylistType compositionPlaylistType = null;
-
-        switch (coreConstraintsVersion) {
-            case "org.smpte_ra.schemas.st2067_2_2013": {
-                org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType compositionPlaylistTypeJaxb =
-                        (org.smpte_ra.schemas.st2067_2_2013.CompositionPlaylistType) jaxbElement.getValue();
-
-                compositionPlaylistType = CompositionModel_st2067_2_2013.getCompositionPlaylist(compositionPlaylistTypeJaxb,
-                        imfErrorLogger);
-            }
-            break;
-            case "org.smpte_ra.schemas.st2067_2_2016": {
-                org.smpte_ra.schemas.st2067_2_2016.CompositionPlaylistType compositionPlaylistTypeJaxb = (org.smpte_ra.schemas.st2067_2_2016.CompositionPlaylistType) jaxbElement.getValue();
-
-                compositionPlaylistType = CompositionModel_st2067_2_2016.getCompositionPlaylist(compositionPlaylistTypeJaxb, imfErrorLogger);
-            }
-            break;
-            default:
-                String message = String.format("Please check the CPL document, currently we only support the " +
-                        "following CoreConstraints schema URIs %s", serializeIMFCoreConstaintsSchemasToString
-                        (supportedIMFCoreConstraintsSchemas));
-                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger
-                        .IMFErrors.ErrorLevels.FATAL, message);
-                throw new IMFException(message, imfErrorLogger);
-
+        else
+        {
+            String message = String.format("Please check the CPL document and namespace URI, currently we " +
+                    "only support the following schema URIs %s", supportedCPLSchemaURIs);
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR, IMFErrorLogger
+                    .IMFErrors.ErrorLevels.FATAL, message);
+            throw new IMFException(message, imfErrorLogger);
         }
-
-        return compositionPlaylistType;
     }
 
     /**

--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFMarkerResourceType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFMarkerResourceType.java
@@ -20,6 +20,7 @@ package com.netflix.imflibrary.st2067_2;
 
 import javax.annotation.concurrent.Immutable;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -39,14 +40,9 @@ public final class IMFMarkerResourceType extends IMFBaseResourceType {
                                  List<IMFMarkerType> markerList )
     {
         super(id, editRate, intrinsicDuration, entryPoint, sourceDuration, repeatCount);
-        markerList.sort(new Comparator<IMFMarkerType>() {
-            @Override
-            public int compare(IMFMarkerType o1, IMFMarkerType o2) {
-                return o1.getOffset().compareTo(o2.getOffset());
-            }
-        });
+        markerList.sort(Comparator.comparing(IMFMarkerType::getOffset));
 
-        this.markerList = markerList;
+        this.markerList = Collections.unmodifiableList(markerList);
     }
 
     /**

--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFSegmentType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFSegmentType.java
@@ -19,6 +19,7 @@
 package com.netflix.imflibrary.st2067_2;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,7 +33,7 @@ final class IMFSegmentType {
     public IMFSegmentType(String id,
                           List<IMFSequenceType> sequenceList){
         this.id = id;
-        this.sequenceList = sequenceList;
+        this.sequenceList = Collections.unmodifiableList(sequenceList);
     }
 
     /**

--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFSequenceType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFSequenceType.java
@@ -19,6 +19,7 @@
 package com.netflix.imflibrary.st2067_2;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,7 +39,7 @@ final class IMFSequenceType {
     {
         this.id             = id;
         this.trackId        = trackId;
-        this.resourceList   = (List<IMFBaseResourceType>)resourceList;
+        this.resourceList   = Collections.unmodifiableList(resourceList);
         this.type           = type;
     }
 


### PR DESCRIPTION
This refactoring work will greatly simplify some of the next changes that will be needed to add support for IMF 2020.

I tried to move most of the version-specific parsing logic into the CompositionModel classes, so that IMFCompositionPlaylistType could be more agnostic to the underlying JAXB classes.
The conversion and parsing logic was refactored into separate methods.
