### PR TITLE
Remove codecov usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ jdk:
 - openjdk8
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
-after_success:
-- bash <(curl -s https://codecov.io/bash)
 cache:
   directories:
   - "$HOME/.gradle"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![codecov](https://codecov.io/gh/Netflix/photon/branch/master/graph/badge.svg)](https://codecov.io/gh/Netflix/photon)
 
 # Photon
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "generated"  # ignore folder and all its contents


### PR DESCRIPTION
While we were not affected by the https://about.codecov.io/security-update/

We suggest to move away from this pattern of curling codecov.io to get the bash script

This is to prevent potential problems in the future