### PR TITLE
equalsWithMask() now compares all UL bytes

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st0377/header/UL.java
+++ b/src/main/java/com/netflix/imflibrary/st0377/header/UL.java
@@ -135,7 +135,7 @@ public class UL {
      */
     public boolean equalsWithMask(UL ul, int byteMask) {
 
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < 16; i++) {
             if ((byteMask & 0x8000) != 0 && this.ul[i] != ul.ul[i])
                 return false;
 


### PR DESCRIPTION
Closes #324 