### PR TITLE
Fixed generation of mismatched sourceEncoding and essenceDescriptor IDs

### DIFF
--- a/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
@@ -155,14 +155,15 @@ public class CompositionPlaylistBuilder_2016 {
             IMFEssenceComponentVirtualTrack essenceTrack = (IMFEssenceComponentVirtualTrack) virtualTrack;
             for (IMFTrackFileResourceType trackResource : essenceTrack.getTrackFileResourceList()) {
                 UUID sourceEncoding = trackEncodingMap.get(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()));
+                // To avoid mismatched essenceDescriptorId and sourceEncodingId, we use the trackFileIdToEssenceDescriptorIdMap. If this function is called by the deprecated constructor,
+                // we run the risk of mismatch ONLY if there are multiple essence descriptors for the same virtualTrackFile in the input CPL.
                 if (sourceEncoding == null) {
                     if (trackFileIdToEssenceDescriptorIdMap != null) {
-                        trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), trackFileIdToEssenceDescriptorIdMap.get(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId())) /*UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding())*/);
+                        trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), trackFileIdToEssenceDescriptorIdMap.get(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId())));
                     }
                     else {
                         trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding()));
                     }
-                    // trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), trackFileIdToEssenceDescriptorIdMap.get(trackResource.getTrackFileId()) /*UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding())*/);
                 }
             }
         }

--- a/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/CompositionPlaylistBuilder_2016.java
@@ -128,7 +128,8 @@ public class CompositionPlaylistBuilder_2016 {
                                            @Nonnull Map<UUID, IMPBuilder.IMFTrackFileInfo> trackFileInfoMap,
                                            @Nonnull File workingDirectory,
                                            @Nonnull List<IMFEssenceDescriptorBaseType> imfEssenceDescriptorBaseTypeList,
-                                           @Nonnull String coreConstraintsSchema){
+                                           @Nonnull String coreConstraintsSchema,
+                                           Map<UUID, UUID> trackFileIdToEssenceDescriptorIdMap){
         this.uuid = uuid;
         this.annotationText = annotationText;
         this.issuer = issuer;
@@ -155,7 +156,13 @@ public class CompositionPlaylistBuilder_2016 {
             for (IMFTrackFileResourceType trackResource : essenceTrack.getTrackFileResourceList()) {
                 UUID sourceEncoding = trackEncodingMap.get(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()));
                 if (sourceEncoding == null) {
-                    trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding()));
+                    if (trackFileIdToEssenceDescriptorIdMap != null) {
+                        trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), trackFileIdToEssenceDescriptorIdMap.get(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId())) /*UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding())*/);
+                    }
+                    else {
+                        trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding()));
+                    }
+                    // trackEncodingMap.put(UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getTrackFileId()), trackFileIdToEssenceDescriptorIdMap.get(trackResource.getTrackFileId()) /*UUIDHelper.fromUUIDAsURNStringToUUID(trackResource.getSourceEncoding())*/);
                 }
             }
         }
@@ -189,7 +196,7 @@ public class CompositionPlaylistBuilder_2016 {
                                            @Nonnull Map<UUID, IMPBuilder.IMFTrackFileInfo> trackFileInfoMap,
                                            @Nonnull File workingDirectory,
                                            @Nonnull List<IMFEssenceDescriptorBaseType> imfEssenceDescriptorBaseTypeList){
-        this(uuid, annotationText, issuer, creator, virtualTracks, compositionEditRate, Collections.singleton(applicationId), totalRunningTime, trackFileInfoMap, workingDirectory, imfEssenceDescriptorBaseTypeList, CoreConstraints.NAMESPACE_IMF_2016);
+        this(uuid, annotationText, issuer, creator, virtualTracks, compositionEditRate, Collections.singleton(applicationId), totalRunningTime, trackFileInfoMap, workingDirectory, imfEssenceDescriptorBaseTypeList, CoreConstraints.NAMESPACE_IMF_2016, null);
     }
 
     /**

--- a/src/main/java/com/netflix/imflibrary/writerTools/IMPBuilder.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/IMPBuilder.java
@@ -9,12 +9,7 @@ import com.netflix.imflibrary.exceptions.IMFAuthoringException;
 import com.netflix.imflibrary.exceptions.MXFException;
 import com.netflix.imflibrary.st0377.HeaderPartition;
 import com.netflix.imflibrary.st0377.header.InterchangeObject;
-import com.netflix.imflibrary.st2067_2.AbstractApplicationComposition;
-import com.netflix.imflibrary.st2067_2.Composition;
-import com.netflix.imflibrary.st2067_2.CoreConstraints;
-import com.netflix.imflibrary.st2067_2.IMFEssenceComponentVirtualTrack;
-import com.netflix.imflibrary.st2067_2.IMFEssenceDescriptorBaseType;
-import com.netflix.imflibrary.st2067_2.IMFTrackFileResourceType;
+import com.netflix.imflibrary.st2067_2.*;
 import com.netflix.imflibrary.utils.ByteArrayByteRangeProvider;
 import com.netflix.imflibrary.utils.ByteArrayDataProvider;
 import com.netflix.imflibrary.utils.ByteProvider;
@@ -432,7 +427,8 @@ public class IMPBuilder {
                 trackFileInfoMap,
                 workingDirectory,
                 imfEssenceDescriptorBaseTypeList,
-                coreConstraintsSchema);
+                coreConstraintsSchema,
+                trackFileIdToEssenceDescriptorIdMap);
 
         imfErrorLogger.addAllErrors(compositionPlaylistBuilder_2016.build());
 


### PR DESCRIPTION
When an input CPL has multiple essence descriptors for a single track file, Photon can generate a CPL where the sourceEncodingId and the essenceDescriptorId do not match. This fix corrects this behavior.