### PR TITLE
Unblocking failed test compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     /*compile "com.sandflow:regxmllib:${revRegXMLSNAPSHOT}"*/
     testImplementation "org.mockito:mockito-core:3.3+"
     testImplementation "org.testng:testng:7.5+"
+    testImplementation "org.slf4j:slf4j-simple:latest.release"
 }
 
 test {


### PR DESCRIPTION
specifying `slf4j` implementation should unblock failing tests