### PR TITLE
Feature: detect duplicate resource ids in virtual track

### DIFF
--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFTrackFileResourceType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFTrackFileResourceType.java
@@ -109,4 +109,33 @@ public final class IMFTrackFileResourceType extends IMFBaseResourceType {
 
         return  result;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IMFTrackFileResourceType otherImfTrackFileResourceType = (IMFTrackFileResourceType) o;
+        return equivalent(otherImfTrackFileResourceType);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        // hash = 31 * hash * id.hashCode();
+        hash = 31 * hash * trackFileId.hashCode();
+        hash = 31 * hash * editRate.hashCode();
+        hash = 31 * hash * intrinsicDuration.hashCode();
+        hash = 31 * hash * entryPoint.hashCode();
+        hash = 31 * hash * sourceDuration.hashCode();
+        hash = 31 * hash * repeatCount.hashCode();
+        hash = 31 * hash * sourceEncoding.hashCode();
+        // hash = 31 * hash * getHash().hashCode();
+        // hash = 31 * hash * hashAlgorithm.hashCode();
+        return hash;
+    }
+
 }

--- a/src/test/resources/TestIMP/Application2/CPL_0eb3d1b9-b77b-4d3f-bbe5-7c69b15dca85_rgba_coding_equation.xml
+++ b/src/test/resources/TestIMP/Application2/CPL_0eb3d1b9-b77b-4d3f-bbe5-7c69b15dca85_rgba_coding_equation.xml
@@ -481,7 +481,7 @@
                             <TrackFileId>urn:uuid:61d91654-2650-4abf-abbc-ad2c7f640bf8</TrackFileId>
                         </Resource>
                         <Resource xsi:type="TrackFileResourceType">
-                            <Id>urn:uuid:a5586a0b-1e3f-4c99-9de5-5a66f20cbaf8</Id>
+                            <Id>urn:uuid:a5586a0b-1e3f-4c99-9de5-5a66f20cbaf9</Id>
                             <EditRate>60000 1001</EditRate>
                             <IntrinsicDuration>40</IntrinsicDuration>
                             <EntryPoint>20</EntryPoint>


### PR DESCRIPTION
Spec says:
"The Id element shall identify this specific Resource instance. The means of identifying the underlying Asset is
left to subclasses. No two Resouces shall have the same ID value unless they are identical."

This is not currently being enforced. This PR adds a check for this condition.