### PR TITLE
Generating non Base-64-encoded hashes for CPL files in IMPBuilder

### DIFF
--- a/src/main/java/com/netflix/imflibrary/writerTools/IMPBuilder.java
+++ b/src/main/java/com/netflix/imflibrary/writerTools/IMPBuilder.java
@@ -154,7 +154,7 @@ public class IMPBuilder {
         if(!cplFile.exists()){
             throw new IMFAuthoringException(String.format("CompositionPlaylist file does not exist, cannot generate the rest of the documents"));
         }
-        byte[] cplHash = IMFUtils.generateSHA1HashAndBase64Encode(cplFile);
+        byte[] cplHash = IMFUtils.generateSHA1Hash(cplFile);
 
         /**
          * Build the PackingList
@@ -357,7 +357,7 @@ public class IMPBuilder {
         if(!cplFile.exists()){
             throw new IMFAuthoringException(String.format("CompositionPlaylist file does not exist in the working directory %s, cannot generate the rest of the documents", workingDirectory.getAbsolutePath()));
         }
-        byte[] cplHash = IMFUtils.generateSHA1HashAndBase64Encode(cplFile);
+        byte[] cplHash = IMFUtils.generateSHA1Hash(cplFile);
 
 
         /**
@@ -555,7 +555,7 @@ public class IMPBuilder {
         if(!cplFile.exists()){
             throw new IMFAuthoringException(String.format("CompositionPlaylist file does not exist in the working directory %s, cannot generate the rest of the documents", workingDirectory.getAbsolutePath()));
         }
-        byte[] cplHash = IMFUtils.generateSHA1HashAndBase64Encode(cplFile);
+        byte[] cplHash = IMFUtils.generateSHA1Hash(cplFile);
 
         /**
          * Build the PackingList
@@ -756,7 +756,7 @@ public class IMPBuilder {
         if(!cplFile.exists()){
             throw new IMFAuthoringException(String.format("CompositionPlaylist file does not exist in the working directory %s, cannot generate the rest of the documents", workingDirectory.getAbsolutePath()));
         }
-        byte[] cplHash = IMFUtils.generateSHA1HashAndBase64Encode(cplFile);
+        byte[] cplHash = IMFUtils.generateSHA1Hash(cplFile);
 
         /**
          * Build the PackingList


### PR DESCRIPTION
Previously, we generated Base-64 encoded SHA-1 hahses, but JAXB serialization already performs base-64 encoding for byte array types. This double-correction led to invalid hash values for CPL files in the PKL, since they were 40 bytes in length rather than 28.