### PR TITLE
Explicitly adding JAXB dependencies to Photon.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.3+"
     testImplementation "org.testng:testng:7.5+"
     testImplementation "org.slf4j:slf4j-simple:latest.release"
+
+    // JAX-B dependencies for JDK 9+
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+    implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
 }
 
 test {


### PR DESCRIPTION
Explicitly adding JAXB dependencies to Photon in order to make it compatible with jdk11+. Past this version, the dependencies will not be pulled in transitively.