### PR TITLE
Add APP2.HT.REV and APP2.HT.IRV constraint sets validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,9 @@ dependencies {
     /*compile "com.sandflow:regxmllib:${revRegXMLSNAPSHOT}"*/
     testImplementation "org.mockito:mockito-core:3.3+"
     testImplementation "org.testng:testng:7.5+"
-    testImplementation "org.slf4j:slf4j-simple:latest.release"
+    implementation "org.slf4j:slf4j-simple:1.7.2"
+    implementation "org.slf4j:slf4j-api:1.7.2"
+
 
     // JAX-B dependencies for JDK 9+
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"

--- a/codequality/findbugs-excludeFilter-GeneratedCode.xml
+++ b/codequality/findbugs-excludeFilter-GeneratedCode.xml
@@ -38,4 +38,9 @@
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE" />
     </Match>
 
+    <!-- It should be possible to define a class that is tested but not fully used at this time -->
+    <Match>
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -384,6 +384,22 @@ public class Application2E2021 extends AbstractApplicationComposition {
             if (p.cod.precinctSizes[i] != 0x88)
                 return false;
 
+        /* magbp */
+
+        int b = p.csiz[0].ssiz + 2;
+
+        if (isIRV) {
+            b += 2 + p.cod.multiComponentTransform;
+            if (p.cod.numDecompLevels > 5)
+                b += 1;
+        } else {
+            if (p.cod.multiComponentTransform == 1 && p.csiz[0].ssiz > 9)
+                b += 1;
+        }
+
+        if (((p.cap.ccap[0] & 0b11111) + 8) > b)
+            return false;
+
         return true;
     }
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -334,6 +334,8 @@ public class Application2E2021 extends AbstractApplicationComposition {
             return false;
         }
 
+        /* progression order */
+
         if (p.cod.progressionOrder != 0b00000010)
             logger.addError(
                 IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -277,6 +277,48 @@ public class Application2E2021 extends AbstractApplicationComposition {
         if (p.xosiz != 0 || p.yosiz != 0 || p.xtosiz != 0 || p.ytosiz != 0)
             return false;
 
+        if (p.xtsiz < p.xsiz || p.ytsiz < p.ysiz)
+            return false;
+
+
+        /* components constraints */
+
+        if (p.csiz.length <= 0 || p.csiz.length > 4)
+            return false;
+
+        if (p.csiz[0].ssiz > 15 || p.csiz[0].ssiz < 7)
+            return false;
+
+        for (int i = 0; i < p.csiz.length; i++) {
+            if (p.csiz[i].yrsiz != 1)
+                return false;
+            if (p.csiz[i].xrsiz != 1) {
+                if (i == 2 && p.csiz[i].xrsiz != 2)
+                    return false;
+
+                if (i == 3 && p.csiz[3].xrsiz != p.csiz[2].xrsiz)
+                    return false;
+            }
+            if (p.csiz[i].ssiz != p.csiz[0].ssiz)
+                return false;
+        }
+
+        /* CAP constraints */
+
+        if (p.cap == null || p.cap.pcap != 131072 || p.cap.ccap.length != 1) {
+            /* codestream shall require only Part 15 capabilities */
+            return false;
+        }
+
+        if ((p.cap.ccap[0] & 0b1111000000000000) != 0) {
+            /* Bits 12-15 of Ccap15 shall be 0 */
+            return false;
+        }
+
+        boolean isIRV = (p.cap.ccap[0] & 0b10000) != 0;
+
+        /*  */
+
         return true;
     }
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -325,8 +325,12 @@ public class Application2E2021 extends AbstractApplicationComposition {
             return false;
         }
 
-        if (p.cod.scod != 0b01000000) {
-            /* COD missing */
+        /* no scod constraints? */
+
+        /* code-block style */
+
+        if (p.cod.cbStyle != 0b01000000) {
+            /* bad code-block style */
             return false;
         }
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -307,7 +307,7 @@ public class Application2E2021 extends AbstractApplicationComposition {
             logger.addError(
                     IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
                     IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
-                    String.format("APP2.HT: Invalid number (%s) of components", p.csiz.toString()));
+                    String.format("APP2.HT: Invalid number (%d) of components", p.csiz.length));
             isValid = false;
         }
 
@@ -354,13 +354,13 @@ public class Application2E2021 extends AbstractApplicationComposition {
         }
         /* CAP constraints */
 
-        if (p.cap == null || p.cap.pcap != 131072 || p.cap.ccap.length != 1) {
+        if (p.cap == null || p.cap.pcap != 131072 || p.cap.ccap == null || p.cap.ccap.length != 1) {
             /* codestream shall require only Part 15 capabilities */
             logger.addError(
                     IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
                     IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
                     "APP2.HT: missing or invalid CAP marker");
-            isValid = false;
+            return false;
         }
 
         if ((p.cap.ccap[0] & 0b1111000000000000) != 0) {

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -311,6 +311,38 @@ public class Application2E2021 extends AbstractApplicationComposition {
             isValid = false;
         }
 
+        /* x sub-sampling */
+        if (p.csiz[0].xrsiz != 1) {
+            logger.addError(
+                    IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
+                    "APP2.HT: invalid horizontal sub-sampling for component 1");
+            isValid = false;
+        }
+        if (p.csiz.length > 1 && p.csiz[1].xrsiz != 1 &&
+            (p.csiz.length <= 2 || p.csiz[1].xrsiz != 2 || p.csiz[2].xrsiz != 2)) {
+            logger.addError(
+                    IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
+                    "APP2.HT: invalid horizontal sub-sampling for component 2");
+            isValid = false;
+        }
+        if (p.csiz.length > 2 && p.csiz[2].xrsiz != 1 && (p.csiz[1].xrsiz != 2 || p.csiz[2].xrsiz != 2)) {
+            logger.addError(
+                    IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
+                    "APP2.HT: invalid horizontal sub-sampling for component 3");
+            isValid = false;
+        }
+        if (p.csiz.length > 3 && p.csiz[3].xrsiz != 1) {
+            logger.addError(
+                    IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
+                    "APP2.HT: invalid horizontal sub-sampling for component 4");
+            isValid = false;
+        }
+
+        /* y sub-sampling and sample width */
         if (p.csiz[0].ssiz > 15 || p.csiz[0].ssiz < 7) {
             logger.addError(
                     IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
@@ -318,7 +350,6 @@ public class Application2E2021 extends AbstractApplicationComposition {
                     String.format("APP2.HT: Invalid bit depth (%d)", p.csiz[0].ssiz + 1));
             isValid = false;
         }
-
         for (int i = 0; i < p.csiz.length; i++) {
             if (p.csiz[i].yrsiz != 1) {
                 logger.addError(
@@ -326,23 +357,6 @@ public class Application2E2021 extends AbstractApplicationComposition {
                         IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
                         String.format("APP2.HT: invalid vertical sub-sampling for component %d", i));
                 isValid = false;
-            }
-            if (p.csiz[i].xrsiz != 1) {
-                if (i == 2 && p.csiz[i].xrsiz != 2) {
-                    logger.addError(
-                            IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
-                            IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
-                            "APP2.HT: invalid horizontal sub-sampling for component 2");
-                    isValid = false;
-                }
-
-                if (i == 3 && p.csiz[3].xrsiz != p.csiz[2].xrsiz) {
-                    logger.addError(
-                            IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
-                            IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
-                            "APP2.HT: invalid horizontal sub-sampling for component 3");
-                    isValid = false;
-                }
             }
             if (p.csiz[i].ssiz != p.csiz[0].ssiz) {
                 logger.addError(

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -487,18 +487,18 @@ public class Application2E2021 extends AbstractApplicationComposition {
 
         /* magbp */
 
-        int b = p.csiz[0].ssiz + 2;
 
+        int maxB = p.csiz[0].ssiz + 2;
         if (isReversibleFilter) {
-            b += 2 + p.cod.multiComponentTransform;
+            maxB += 2 + p.cod.multiComponentTransform;
             if (p.cod.numDecompLevels > 5)
-                b += 1;
-        } else {
-            if (p.cod.multiComponentTransform == 1 && p.csiz[0].ssiz > 9)
-                b += 1;
+                maxB += 1;
+        } else if (p.cod.multiComponentTransform == 1 && p.csiz[0].ssiz > 9) {
+            maxB += 1;
         }
 
-        if (((p.cap.ccap[0] & 0b11111) + 8) > b) {
+        int codestreamB = (p.cap.ccap[0] & 0b11111) + 8;
+        if (codestreamB > maxB) {
             logger.addError(
                 IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
                 IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -372,7 +372,7 @@ public class Application2E2021 extends AbstractApplicationComposition {
             isValid = false;
         }
 
-        boolean isIRV = (p.cap.ccap[0] & 0b10000) != 0;
+        boolean isHTREV = (p.cap.ccap[0] & 0b100000) == 0;
 
         /* COD */
 
@@ -455,17 +455,13 @@ public class Application2E2021 extends AbstractApplicationComposition {
 
         /* transformation */
 
-        if ((!isIRV) && p.cod.transformation == 0 /* 9-7 irreversible filter */) {
+        boolean isReversibleFilter = (p.cod.transformation == 1);
+
+        if (isHTREV && !isReversibleFilter) {
             logger.addError(
                 IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
                 IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
-                "APP2.HT: 9-7 irreversible filter must be used for APP2.HT.IRV");
-            isValid = false;
-        } else if (isIRV && p.cod.transformation == 1 /* 5-3 reversible filter */) {
-            logger.addError(
-                IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
-                IMFErrorLogger.IMFErrors.ErrorLevels.FATAL,
-                "APP2.HT: 5-3 reversible filter must be used for APP2.HT.REV");
+                "APP2.HT: 9-7 irreversible filter is used but HTREV is signaled in CAP");
             isValid = false;
         }
 
@@ -493,7 +489,7 @@ public class Application2E2021 extends AbstractApplicationComposition {
 
         int b = p.csiz[0].ssiz + 2;
 
-        if (isIRV) {
+        if (isReversibleFilter) {
             b += 2 + p.cod.multiComponentTransform;
             if (p.cod.numDecompLevels > 5)
                 b += 1;

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -4,9 +4,11 @@ import com.netflix.imflibrary.Colorimetry;
 import com.netflix.imflibrary.Colorimetry.ColorModel;
 import com.netflix.imflibrary.Colorimetry.Quantization;
 import com.netflix.imflibrary.Colorimetry.Sampling;
+import com.netflix.imflibrary.st0377.header.GenericPictureEssenceDescriptor.FrameLayoutType;
 import com.netflix.imflibrary.st0377.header.UL;
 import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.st2067_2.ApplicationCompositionFactory.ApplicationCompositionType;
+import com.netflix.imflibrary.st2067_2.CompositionImageEssenceDescriptorModel.J2KHeaderParameters;
 import com.netflix.imflibrary.utils.Fraction;
 import com.netflix.imflibrary.JPEG2000;
 
@@ -269,13 +271,22 @@ public class Application2E2021 extends AbstractApplicationComposition {
         }
     }
 
+    private static boolean isValidHT(CompositionImageEssenceDescriptorModel imageDescriptor) {
+        J2KHeaderParameters p = imageDescriptor.getJ2KHeaderParameters();
+
+        if (p.xosiz != 0 || p.yosiz != 0 || p.xtosiz != 0 || p.ytosiz != 0)
+            return false;
+
+        return true;
+    }
+
     public static boolean isValidJ2KProfile(CompositionImageEssenceDescriptorModel imageDescriptor) {
         UL essenceCoding = imageDescriptor.getPictureEssenceCodingUL();
         Integer width = imageDescriptor.getStoredWidth();
         Integer height = imageDescriptor.getStoredHeight();
 
         if (JPEG2000.isAPP2HT(essenceCoding))
-            return true;
+            return isValidHT(imageDescriptor);
 
         if (JPEG2000.isIMF4KProfile(essenceCoding))
             return width > 2048 && width <= 4096 && height > 0 && height <= 3112;

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -355,6 +355,11 @@ public class Application2E2021 extends AbstractApplicationComposition {
             return false;
         }
 
+        /* number of layers */
+
+        if (p.cod.numLayers != 1)
+            return false;
+
         /* code-block sizes */
 
         if (p.cod.ycb < 5 || p.cod.ycb > 6)
@@ -362,6 +367,22 @@ public class Application2E2021 extends AbstractApplicationComposition {
 
         if (p.cod.xcb < 5 || p.cod.xcb > 7)
             return false;
+
+        /* transformation */
+
+        if ((!isIRV) && p.cod.transformation == 0 /* 9-7 irreversible filter */)
+            return false;
+        else if (isIRV && p.cod.transformation == 1 /* 5-3 reversible filter */)
+            return false;
+
+        /* precinct size */
+
+        if (p.cod.precinctSizes.length == 0 || p.cod.precinctSizes[0] != 0x77)
+            return false;
+
+        for (int i = 1; i < p.cod.precinctSizes.length; i++)
+            if (p.cod.precinctSizes[i] != 0x88)
+                return false;
 
         return true;
     }

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application2E2021.java
@@ -342,6 +342,27 @@ public class Application2E2021 extends AbstractApplicationComposition {
                 IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
                 "JPEG 2000 progression order is not RPCL");
 
+        /* resolution layers */
+        if (p.cod.numDecompLevels == 0)
+            return false;
+
+        long maxSz = Math.max(p.xsiz, p.ysiz);
+        if (maxSz <= 2048 && p.cod.numDecompLevels > 5) {
+            return false;
+        } else if (maxSz <= 4096 && p.cod.numDecompLevels > 6) {
+            return false;
+        } else if (maxSz <= 8192 && p.cod.numDecompLevels > 7) {
+            return false;
+        }
+
+        /* code-block sizes */
+
+        if (p.cod.ycb < 5 || p.cod.ycb > 6)
+            return false;
+
+        if (p.cod.xcb < 5 || p.cod.xcb > 7)
+            return false;
+
         return true;
     }
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
@@ -423,7 +423,12 @@ public final class CompositionImageEssenceDescriptorModel {
             short cbHeight;
             short cbStyle;
             short transformation;
-            short precinctSize[];
+            short precinctSizes[];
+        }
+
+        static public class QCD {
+            short sqcd;
+            int spqcd[];
         }
 
         Integer rsiz;
@@ -437,7 +442,7 @@ public final class CompositionImageEssenceDescriptorModel {
         Long ytosiz;
         CSiz[] csiz;
         COD cod;
-        byte[] qcd;
+        QCD qcd;
         CAP cap;
 
     }
@@ -552,7 +557,7 @@ public final class CompositionImageEssenceDescriptorModel {
         /* COD */
         String codString = j2kNode.getFieldAsString("CodingStyleDefault");
 
-        if (codString != null && codString.length() >= 20) {
+        if (codString != null && codString.length() >= 20 && (codString.length() % 2 == 0)) {
 
             params.cod = new J2KHeaderParameters.COD();
 
@@ -566,8 +571,35 @@ public final class CompositionImageEssenceDescriptorModel {
             params.cod.cbStyle = (short) Integer.parseInt(codString.substring(16, 18), 16);
             params.cod.transformation = (short) Integer.parseInt(codString.substring(18, 20), 16);
 
+            params.cod.precinctSizes = new short[(codString.length() - 20)/2];
+
+            for (int i = 0; i < params.cod.precinctSizes.length; i++) {
+                params.cod.precinctSizes[i] = (short) Integer.parseInt(codString.substring(20 + 2 * i, 22 + 2 * i), 16);
+            }
+
         } else {
             /* missing COD */
+        }
+
+        /* QCD */
+        String qcdString = j2kNode.getFieldAsString("QuantizationDefault");
+
+        if (qcdString != null && qcdString.length() >= 2 && (qcdString.length() % 2 == 0)) {
+
+            params.qcd = new J2KHeaderParameters.QCD();
+
+            params.qcd.sqcd = (short) Integer.parseInt(qcdString.substring(0, 2), 16);
+
+            int spqcdSize = (params.qcd.sqcd & 0b11111) == 0 ? 1 : 2;
+
+            params.qcd.spqcd = new int[(qcdString.length() - 2)/(2 * spqcdSize)];
+
+            for (int i = 0; i < params.qcd.spqcd.length; i++) {
+                params.qcd.spqcd[i] = (int) Integer.parseInt(qcdString.substring(2 + 2 * spqcdSize * i, 4 + 2 * spqcdSize * i), 16);
+            }
+
+        } else {
+            /* missing QCD */
         }
 
         return params;

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
@@ -419,8 +419,8 @@ public final class CompositionImageEssenceDescriptorModel {
             int numLayers;
             short multiComponentTransform;
             short numDecompLevels;
-            short cbWidth;
-            short cbHeight;
+            short xcb;
+            short ycb;
             short cbStyle;
             short transformation;
             short precinctSizes[];
@@ -566,8 +566,8 @@ public final class CompositionImageEssenceDescriptorModel {
             params.cod.numLayers = (int) Integer.parseInt(codString.substring(4, 8), 16);
             params.cod.multiComponentTransform = (short) Integer.parseInt(codString.substring(8, 10), 16);
             params.cod.numDecompLevels = (short) Integer.parseInt(codString.substring(10, 12), 16);
-            params.cod.cbWidth = (short) Integer.parseInt(codString.substring(12, 14), 16);
-            params.cod.cbHeight = (short) Integer.parseInt(codString.substring(14, 16), 16);
+            params.cod.xcb = (short) (Integer.parseInt(codString.substring(12, 14), 16) + 2);
+            params.cod.ycb = (short) (Integer.parseInt(codString.substring(14, 16), 16) + 2);
             params.cod.cbStyle = (short) Integer.parseInt(codString.substring(16, 18), 16);
             params.cod.transformation = (short) Integer.parseInt(codString.substring(18, 20), 16);
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
@@ -413,6 +413,18 @@ public final class CompositionImageEssenceDescriptorModel {
             int[] ccap;
         }
 
+        static public class COD {
+            short scod;
+            short progressionOrder;
+            int numLayers;
+            short multiComponentTransform;
+            short numDecompLevels;
+            short cbWidth;
+            short cbHeight;
+            short transformation;
+            short precinctSize[];
+        }
+
         Integer rsiz;
         Long xsiz;
         Long ysiz;
@@ -423,7 +435,7 @@ public final class CompositionImageEssenceDescriptorModel {
         Long xtosiz;
         Long ytosiz;
         CSiz[] csiz;
-        byte[] cod;
+        COD cod;
         byte[] qcd;
         CAP cap;
 
@@ -532,6 +544,19 @@ public final class CompositionImageEssenceDescriptorModel {
 
         }
 
+        /* COD */
+        String codString = j2kNode.getFieldAsString("CodingStyleDefault");
+
+        if (codString != null && codString.length() >= 18) {
+
+            params.cod = new J2KHeaderParameters.COD();
+
+            params.cod.scod = (short) Integer.parseInt(codString.substring(0, 2), 16);
+            params.cod.progressionOrder = (short) Integer.parseInt(codString.substring(2, 6), 16);
+
+        } else {
+            /* missing COD */
+        }
 
         return params;
     }

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
@@ -421,6 +421,7 @@ public final class CompositionImageEssenceDescriptorModel {
             short numDecompLevels;
             short cbWidth;
             short cbHeight;
+            short cbStyle;
             short transformation;
             short precinctSize[];
         }
@@ -519,6 +520,10 @@ public final class CompositionImageEssenceDescriptorModel {
 
             if (pcap != null) {
 
+                params.cap = new J2KHeaderParameters.CAP();
+
+                params.cap.pcap = pcap;
+
                 DOMNodeObjectModel ccapiNode = capNode.getDOMNode("Ccapi");
 
                 if (ccapiNode != null) {
@@ -547,12 +552,19 @@ public final class CompositionImageEssenceDescriptorModel {
         /* COD */
         String codString = j2kNode.getFieldAsString("CodingStyleDefault");
 
-        if (codString != null && codString.length() >= 18) {
+        if (codString != null && codString.length() >= 20) {
 
             params.cod = new J2KHeaderParameters.COD();
 
             params.cod.scod = (short) Integer.parseInt(codString.substring(0, 2), 16);
-            params.cod.progressionOrder = (short) Integer.parseInt(codString.substring(2, 6), 16);
+            params.cod.progressionOrder = (short) Integer.parseInt(codString.substring(2, 4), 16);
+            params.cod.numLayers = (int) Integer.parseInt(codString.substring(4, 8), 16);
+            params.cod.multiComponentTransform = (short) Integer.parseInt(codString.substring(8, 10), 16);
+            params.cod.numDecompLevels = (short) Integer.parseInt(codString.substring(10, 12), 16);
+            params.cod.cbWidth = (short) Integer.parseInt(codString.substring(12, 14), 16);
+            params.cod.cbHeight = (short) Integer.parseInt(codString.substring(14, 16), 16);
+            params.cod.cbStyle = (short) Integer.parseInt(codString.substring(16, 18), 16);
+            params.cod.transformation = (short) Integer.parseInt(codString.substring(18, 20), 16);
 
         } else {
             /* missing COD */

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionImageEssenceDescriptorModel.java
@@ -457,6 +457,7 @@ public final class CompositionImageEssenceDescriptorModel {
         params.xtosiz = j2kNode.getFieldAsLong("XTOsiz");
         params.ytosiz = j2kNode.getFieldAsLong("YTOsiz");
 
+        /* CSizi */
         DOMNodeObjectModel csiziNode = j2kNode.getDOMNode("PictureComponentSizing");
         if (csiziNode != null) {
 
@@ -497,6 +498,40 @@ public final class CompositionImageEssenceDescriptorModel {
         } else {
             /* missing csizi */
         }
+
+        /* CAP */
+        DOMNodeObjectModel capNode = j2kNode.getDOMNode("J2KExtendedCapabilities");
+        if (capNode != null) {
+
+            Integer pcap = capNode.getFieldAsInteger("Pcap");
+
+            if (pcap != null) {
+
+                DOMNodeObjectModel ccapiNode = capNode.getDOMNode("Ccapi");
+
+                if (ccapiNode != null) {
+
+                    List<Integer> values = ccapiNode.getFieldsAsInteger("UInt16");
+
+                    params.cap.ccap = new int[values.size()];
+
+                    for (int i = 0; i < params.cap.ccap.length; i++) {
+                        if (values.get(i) != null) {
+                            params.cap.ccap[i] = values.get(i);
+                        } else {
+                            /* bad ccapi value */
+                        }
+                    }
+
+                } else {
+                    /* missing Ccapi */
+                }
+            } else {
+                /* missing Pcap */
+            }
+
+        }
+
 
         return params;
     }

--- a/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
+++ b/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
@@ -754,8 +754,8 @@ public class DOMNodeObjectModel {
 
         Node child = this.getNode().getFirstChild();
         while (child != null) {
-            if (child.getNodeType() == Node.ELEMENT_NODE && child.getLocalName() == name)
-                values.add(Integer.getInteger(child.getTextContent()));
+            if (child.getNodeType() == Node.ELEMENT_NODE && child.getLocalName().equals(name))
+                values.add(Integer.parseInt(child.getTextContent()));
 
             child = child.getNextSibling();
         }

--- a/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
+++ b/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
@@ -744,6 +744,28 @@ public class DOMNodeObjectModel {
     }
 
     /**
+     * A method to obtain set of Integer values for a field within DOMNodeObjectModel
+     * @param name the LocalName for the field
+     * @return Returns a list of field values
+     */
+    public List<Integer> getFieldsAsInteger(String name) {
+
+        List<Integer> values = new ArrayList<Integer>();
+
+        Node child = this.getNode().getFirstChild();
+        while (child != null) {
+            if (child.getNodeType() != Node.ELEMENT_NODE || child.getLocalName() != name)
+                continue;
+
+            values.add(Integer.getInteger(child.getTextContent()));
+
+            child = child.getNextSibling();
+        }
+
+        return values;
+    }
+
+    /**
      * A method to obtain set of String values for a field within DOMNodeObjectModel
      * @param name the LocalName for the field
      * @return Returns a set of field values

--- a/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
+++ b/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
@@ -677,6 +677,25 @@ public class DOMNodeObjectModel {
     }
 
     /**
+     * A method to obtain value of a field within DOMNodeObjectModel as a Short
+     * @param name the LocalName for the field
+     * @return Returns field value as a Short
+     */
+    @Nullable
+    public Short getFieldAsShort(String name) {
+        String value = getFieldAsString(name);
+        try {
+            if(value != null)
+                return Short.valueOf(value);
+        }
+        catch(Exception e) {
+            return null;
+        }
+        return null;
+    }
+
+
+    /**
      * A method to obtain value of a field within DOMNodeObjectModel as an Integer
      * @param name the LocalName for the field
      * @return Returns field value as an Integer
@@ -729,7 +748,6 @@ public class DOMNodeObjectModel {
      * @param name the LocalName for the field
      * @return Returns a set of field values
      */
-    @Nullable
     void getFieldsAsStringRecursive(Set<String> values, String name) {
         try {
             Set<String> matchingValues = this.getFields().entrySet().stream().filter(e -> e.getKey().getLocalName().equals(name)).map(Map.Entry::getValue).map(Map::keySet).flatMap(Set::stream).collect(Collectors.toSet());

--- a/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
+++ b/src/main/java/com/netflix/imflibrary/utils/DOMNodeObjectModel.java
@@ -754,10 +754,8 @@ public class DOMNodeObjectModel {
 
         Node child = this.getNode().getFirstChild();
         while (child != null) {
-            if (child.getNodeType() != Node.ELEMENT_NODE || child.getLocalName() != name)
-                continue;
-
-            values.add(Integer.getInteger(child.getTextContent()));
+            if (child.getNodeType() == Node.ELEMENT_NODE && child.getLocalName() == name)
+                values.add(Integer.getInteger(child.getTextContent()));
 
             child = child.getNextSibling();
         }

--- a/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
@@ -199,5 +199,31 @@ public class Application2ExtendedCompositionTest
 
         Assert.assertEquals(p.rsiz, 16384);
 
+        Assert.assertEquals(p.xsiz, 1920);
+        Assert.assertEquals(p.ysiz, 1080);
+        Assert.assertEquals(p.xosiz, 0);
+        Assert.assertEquals(p.yosiz, 0);
+        Assert.assertEquals(p.xtsiz, 1920);
+        Assert.assertEquals(p.ytsiz, 1080);
+        Assert.assertEquals(p.xtosiz, 0);
+        Assert.assertEquals(p.ytosiz, 0);
+
+        Assert.assertEquals(p.csiz.length, 3);
+        Assert.assertEquals(p.csiz[0].ssiz, 9);
+        Assert.assertEquals(p.csiz[0].yrsiz, 1);
+        Assert.assertEquals(p.csiz[0].xrsiz, 1);
+        Assert.assertEquals(p.csiz[1].ssiz, 9);
+        Assert.assertEquals(p.csiz[1].yrsiz, 1);
+        Assert.assertEquals(p.csiz[1].xrsiz, 1);
+        Assert.assertEquals(p.csiz[2].ssiz, 9);
+        Assert.assertEquals(p.csiz[2].yrsiz, 1);
+        Assert.assertEquals(p.csiz[2].xrsiz, 1);
+
+        Assert.assertEquals(p.cap.pcap, 131072);
+        Assert.assertEquals(p.cap.ccap.length, 1);
+        Assert.assertEquals(p.cap.ccap[0], 2);
+
+        Assert.assertEquals(p.qcd.sqcd, 0x20);
+        Assert.assertEquals(p.qcd.spqcd, new int[] {0x60, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68, 0x68, 0x68, 0x60, 0x60, 0x68});
     }
 }

--- a/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
@@ -2,7 +2,10 @@ package com.netflix.imflibrary.st2067_2;
 
 import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.IMFErrorLoggerImpl;
+import com.netflix.imflibrary.st2067_2.CompositionImageEssenceDescriptorModel.J2KHeaderParameters;
 import com.netflix.imflibrary.utils.ErrorLogger;
+import com.netflix.imflibrary.utils.FileByteRangeProvider;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import testUtils.TestHelper;
@@ -177,5 +180,24 @@ public class Application2ExtendedCompositionTest
         IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
         ApplicationCompositionFactory.getApplicationComposition(inputFile, imfErrorLogger);
         Assert.assertEquals(imfErrorLogger.getErrors().size(), 1);
+    }
+
+    @Test
+    public void validJ2KHeaderParameters() throws IOException
+    {
+        File inputFile = TestHelper.findResourceByPath("TestIMP/Application2E2021/CPL_b2e1ace2-9c7d-4c12-b2f7-24bde303869e.xml");
+        FileByteRangeProvider resourceByteRangeProvider = new FileByteRangeProvider(inputFile);
+        IMFErrorLogger logger = new IMFErrorLoggerImpl();
+        IMFCompositionPlaylistType imfCompositionPlaylistType = IMFCompositionPlaylistType.getCompositionPlayListType(resourceByteRangeProvider, logger);
+        Application2E2021 app = new Application2E2021(imfCompositionPlaylistType);
+        CompositionImageEssenceDescriptorModel image = app.getCompositionImageEssenceDescriptorModel();
+
+        Assert.assertNotNull(image);
+
+        @SuppressWarnings("null")
+        J2KHeaderParameters p = image.getJ2KHeaderParameters();
+
+        Assert.assertEquals(p.rsiz, 16384);
+
     }
 }

--- a/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
@@ -224,6 +224,20 @@ public class Application2ExtendedCompositionTest
         Assert.assertEquals(p.cap.ccap[0], 2);
 
         Assert.assertEquals(p.qcd.sqcd, 0x20);
-        Assert.assertEquals(p.qcd.spqcd, new int[] {0x60, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68, 0x68, 0x68, 0x60, 0x60, 0x68});
+        Assert.assertEquals(p.qcd.spqcd, new int[] { 0x60, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68, 0x68, 0x70, 0x68,
+                0x68, 0x68, 0x60, 0x60, 0x68 });
+
+        /* 01020001010505034001778888888888 */
+        /*  */
+        Assert.assertEquals(p.cod.scod, 0x01);
+        Assert.assertEquals(p.cod.progressionOrder, 0x02);
+        Assert.assertEquals(p.cod.numLayers, 0x0001);
+        Assert.assertEquals(p.cod.multiComponentTransform, 0x01);
+        Assert.assertEquals(p.cod.numDecompLevels, 0x05);
+        Assert.assertEquals(p.cod.cbWidth, 0x05);
+        Assert.assertEquals(p.cod.cbHeight, 0x03);
+        Assert.assertEquals(p.cod.cbStyle, 0x40);
+        Assert.assertEquals(p.cod.transformation, 0x01);
+        Assert.assertEquals(p.cod.precinctSizes, new short[] { 0x77, 0x88, 0x88, 0x88, 0x88, 0x88 });
     }
 }

--- a/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
+++ b/src/test/java/com/netflix/imflibrary/st2067_2/Application2ExtendedCompositionTest.java
@@ -234,8 +234,8 @@ public class Application2ExtendedCompositionTest
         Assert.assertEquals(p.cod.numLayers, 0x0001);
         Assert.assertEquals(p.cod.multiComponentTransform, 0x01);
         Assert.assertEquals(p.cod.numDecompLevels, 0x05);
-        Assert.assertEquals(p.cod.cbWidth, 0x05);
-        Assert.assertEquals(p.cod.cbHeight, 0x03);
+        Assert.assertEquals(p.cod.xcb, 7);
+        Assert.assertEquals(p.cod.ycb, 5);
         Assert.assertEquals(p.cod.cbStyle, 0x40);
         Assert.assertEquals(p.cod.transformation, 0x01);
         Assert.assertEquals(p.cod.precinctSizes, new short[] { 0x77, 0x88, 0x88, 0x88, 0x88, 0x88 });


### PR DESCRIPTION
Closes #370 

Validate the CPL essence descriptors against the APP2.HT.REV and APP2.HT.IRV constraint sets specified in [ST 2067-21, Annex I](https://pub.smpte.org/doc/st2067-21/20221124-pub/).

The PR imposes constraints on the B parameter as suggested at https://github.com/SMPTE/st2067-21/issues/7

To be finalized following the [June 26, 2024 IMF plugfest](https://www.imfug.com/imf-mini-plugfest-june-2024/).