### PR TITLE
Include slf4j "simple" binding/provider as a runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 
     compileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}"
     compileOnly "org.slf4j:slf4j-api:latest.release"
+    runtimeOnly "org.slf4j:slf4j-simple:latest.release"
 
     /**
      * Following includes the RegXMLLib dependency from Maven Central.


### PR DESCRIPTION
A logging provider needs to be specified when running the Photon applications from the commandline (e.g. `com.netflix.imflibrary.app.IMPAnalyzer`) -- otherwise there is an error per #366

However, is this inappropriate for other ways of running Photon? (e.g. as a library)
If so, perhaps this dependency could be moved to a new Gradle "dependency configuration" that can be selected specifically when running Photon applications from the commandline?

Closes #366
