### PR TITLE
Validate marker labels against their scopes

### DIFF
--- a/src/main/java/com/netflix/imflibrary/validation/IMFCPLValidator.java
+++ b/src/main/java/com/netflix/imflibrary/validation/IMFCPLValidator.java
@@ -36,6 +36,20 @@ abstract public class IMFCPLValidator implements ConstraintsValidator {
         add("http://www.smpte-ra.org/schemas/2067-3/2016");
     }});
 
+    private static final String standardMarkerScope2013 =
+            "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers";
+    private static final Map<String, Set<String>> standardMarkerLabelsByScope = Map.of(
+            standardMarkerScope2013, Set.of(
+                    "FFBT", "FFCB", "FFCL", "FFDL", "FFEC", "FFHS", "FFMC", "FFOB",
+                    "FFOC", "FFOI", "FFSP", "FFTC", "FFTS", "FTXC", "FTXE", "FTXM",
+                    "LFBT", "LFCB", "LFCL", "LFDL", "LFEC", "LFHS", "LFMC", "LFOB",
+                    "LFOC", "LFOI", "LFSP", "LFTC", "LFTS", "LTXC", "LTXE", "LTXM",
+                    "FPCI", "FFCO", "LFCO", "FFOA", "LFOA"),
+            "http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers",
+            Set.of("FFDC", "LFDC"),
+            "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+            Set.of("FFEI", "FFER", "FFUN", "LFEI", "LFER", "LFUN"));
+
 
     @Override
     public List<ErrorLogger.ErrorObject> validateEssencePartitionConstraints(@Nonnull PayloadRecord headerPartition, @Nonnull List<PayloadRecord> indexPartitionPayloads) {
@@ -70,7 +84,39 @@ abstract public class IMFCPLValidator implements ConstraintsValidator {
         }
 
 
-        // MARKER TRACK VALIDATION, CONTENT KIND VALUES, ETC
+        imfErrorLogger.addAllErrors(checkMarkerLabelConstraints(imfCompositionPlaylist.getMarkerVirtualTrack()));
+
+        return imfErrorLogger.getErrors();
+    }
+
+    private static List<ErrorLogger.ErrorObject> checkMarkerLabelConstraints(IMFMarkerVirtualTrack markerVirtualTrack)
+    {
+        IMFErrorLogger imfErrorLogger = new IMFErrorLoggerImpl();
+
+        if (markerVirtualTrack == null) {
+            return imfErrorLogger.getErrors();
+        }
+
+        for (IMFMarkerResourceType markerResource : markerVirtualTrack.getMarkerResourceList()) {
+            for (IMFMarkerType marker : markerResource.getMarkerList()) {
+                IMFMarkerType.Label label = marker.getLabel();
+                String scope = label.getScope() == null ? standardMarkerScope2013 : label.getScope();
+                Set<String> permittedLabels = standardMarkerLabelsByScope.get(scope);
+
+                if (permittedLabels == null) {
+                    imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR,
+                            IMFErrorLogger.IMFErrors.ErrorLevels.WARNING,
+                            String.format("Marker Label scope '%s' is not recognized; value '%s' at offset %s cannot be validated",
+                                    scope, label.getValue(), marker.getOffset()));
+                }
+                else if (!permittedLabels.contains(label.getValue())) {
+                    imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR,
+                            IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                            String.format("Marker Label value '%s' at offset %s is not permitted by scope '%s' as specified in SMPTE ST 2067-3",
+                                    label.getValue(), marker.getOffset(), scope));
+                }
+            }
+        }
 
         return imfErrorLogger.getErrors();
     }

--- a/src/main/resources/org/smpte_ra/schemas/st2067_3_2013/imf-cpl.xsd
+++ b/src/main/resources/org/smpte_ra/schemas/st2067_3_2013/imf-cpl.xsd
@@ -245,7 +245,7 @@
           <xs:simpleContent>
             <xs:extension base="xs:string">
               <xs:attribute name="scope" type="xs:anyURI" use="optional"
-                default="http://www.smpte-ra.org/schemas/2067-3/XXXX#standard-markers"/>
+                default="http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers"/>
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>

--- a/src/test/java/com/netflix/imflibrary/validation/IMFCPLValidatorTest.java
+++ b/src/test/java/com/netflix/imflibrary/validation/IMFCPLValidatorTest.java
@@ -4,16 +4,27 @@ import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.IMFErrorLoggerImpl;
 import com.netflix.imflibrary.RESTfulInterfaces.IMPValidator;
 import com.netflix.imflibrary.st2067_2.IMFCompositionPlaylist;
+import com.netflix.imflibrary.utils.ByteArrayByteRangeProvider;
+import com.netflix.imflibrary.utils.ErrorLogger;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import testUtils.TestHelper;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Test(groups = "unit")
 public class IMFCPLValidatorTest
 {
+    private static final String MARKER_CPL = "TestIMP/Netflix_Sony_Plugfest_2015/" +
+            "CPL_BLACKL_202_HD_REC709_178_LAS_8fad47bb-ab01-4f0d-a08c-d1e6c6cb62b4_corrected.xml";
+    private static final String FIRST_MARKER_LABEL = "<Label>FFCL</Label>";
+
 
     @Test
     public void invalidCPLfragmentedVirtulTrack() throws IOException
@@ -64,6 +75,71 @@ public class IMFCPLValidatorTest
 
         logger.getErrors().forEach(e -> {System.out.println(e.getErrorDescription());});
         Assert.assertNotEquals(logger.getErrors().size(), 0);
+    }
+
+    @Test
+    public void invalidStandardMarkerLabelIsReported() throws IOException
+    {
+        List<ErrorLogger.ErrorObject> markerErrors = markerLabelErrors(
+                validateFirstMarker("<Label>Mark5</Label>"));
+
+        Assert.assertEquals(markerErrors.size(), 1);
+        Assert.assertEquals(markerErrors.get(0).getErrorCode(), IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR);
+        Assert.assertEquals(markerErrors.get(0).getErrorLevel(), IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL);
+        Assert.assertTrue(markerErrors.get(0).getErrorDescription().contains("Mark5"));
+        Assert.assertTrue(markerErrors.get(0).getErrorDescription().contains(
+                "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers"));
+    }
+
+    @Test
+    public void unknownMarkerScopeIsReportedAsWarning() throws IOException
+    {
+        String scope = "https://example.com/custom-markers";
+        List<ErrorLogger.ErrorObject> markerErrors = markerLabelErrors(
+                validateFirstMarker(String.format("<Label scope=\"%s\">Mark5</Label>", scope)));
+
+        Assert.assertEquals(markerErrors.size(), 1);
+        Assert.assertEquals(markerErrors.get(0).getErrorCode(), IMFErrorLogger.IMFErrors.ErrorCodes.IMF_CPL_ERROR);
+        Assert.assertEquals(markerErrors.get(0).getErrorLevel(), IMFErrorLogger.IMFErrors.ErrorLevels.WARNING);
+        Assert.assertTrue(markerErrors.get(0).getErrorDescription().contains(scope));
+    }
+
+    @DataProvider(name = "validMarkerLabels")
+    public Object[][] validMarkerLabels()
+    {
+        return new Object[][] {
+                {"<Label>FFOC</Label>"},
+                {"<Label scope=\"http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers\">FFDC</Label>"},
+                {"<Label scope=\"http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers\">FFEI</Label>"}
+        };
+    }
+
+    @Test(dataProvider = "validMarkerLabels")
+    public void validStandardMarkerLabelIsAccepted(String labelElement) throws IOException
+    {
+        Assert.assertTrue(markerLabelErrors(validateFirstMarker(labelElement)).isEmpty());
+    }
+
+    private static List<ErrorLogger.ErrorObject> validateFirstMarker(String labelElement) throws IOException
+    {
+        Path inputFile = TestHelper.findResourceByPath(MARKER_CPL);
+        String cpl = Files.readString(inputFile, StandardCharsets.UTF_8);
+        int markerLabelIndex = cpl.indexOf(FIRST_MARKER_LABEL);
+        Assert.assertTrue(markerLabelIndex >= 0, "Unable to locate the marker label in the CPL fixture");
+
+        String updatedCpl = cpl.substring(0, markerLabelIndex) + labelElement +
+                cpl.substring(markerLabelIndex + FIRST_MARKER_LABEL.length());
+        IMFCompositionPlaylist imfCompositionPlaylist = new IMFCompositionPlaylist(
+                new ByteArrayByteRangeProvider(updatedCpl.getBytes(StandardCharsets.UTF_8)));
+
+        return IMPValidator.validateComposition(imfCompositionPlaylist, null);
+    }
+
+    private static List<ErrorLogger.ErrorObject> markerLabelErrors(List<ErrorLogger.ErrorObject> errors)
+    {
+        return errors.stream()
+                .filter(error -> error.getErrorDescription().contains("Marker Label"))
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## Summary
- validate SMPTE marker labels against the permitted values for their computed scope
- warn when a marker scope is unknown and restore the 2013 schema default scope
- cover invalid, unknown, and valid 2013/2016/2020 marker labels

## Testing
- JDK 11: `./gradlew build`
- JDK 17 and JDK 21: `./gradlew --rerun-tasks test --tests com.netflix.imflibrary.validation.IMFCPLValidatorTest`
- `git diff --check`

Closes #394